### PR TITLE
Fix typo in JeolMicroscope.getCL1

### DIFF
--- a/instamatic/TEMController/jeol_microscope.py
+++ b/instamatic/TEMController/jeol_microscope.py
@@ -157,7 +157,7 @@ class JeolMicroscope:
         return bool(value)
 
     def getCL1(self) -> int:
-        value, result = self.lens3.GetCL2()
+        value, result = self.lens3.GetCL1()
         return value
 
     def getCL2(self) -> int:


### PR DESCRIPTION
HI, here is a minor fix for a typo in jeol_microscope.py.