### PR TITLE
Reset soft trigger acquisition when max frame counter is reached

### DIFF
--- a/instamatic/camera/camera_merlin.py
+++ b/instamatic/camera/camera_merlin.py
@@ -47,6 +47,7 @@ def MPX_CMD(type_cmd: str = 'GET', cmd: str = 'DETECTORSTATUS') -> bytes:
 class CameraMerlin:
     """Camera interface for the Quantum Detectors Merlin camera."""
     START_SIZE = 14
+    MAX_NUMFRAMESTOACQUIRE = 42_949_672_950
 
     def __init__(self, name='merlin'):
         """Initialize camera module."""
@@ -140,11 +141,10 @@ class CameraMerlin:
 
         # Set NUMFRAMESTOACQUIRE to maximum
         # Merlin collects up to this number of frames with a single SOFTTRIGGER acquisition
-        self._frame_number_max = 42_949_672_950
-        self.merlin_set('NUMFRAMESTOACQUIRE', self._frame_number_max)
+        self.merlin_set('NUMFRAMESTOACQUIRE', self.MAX_NUMFRAMESTOACQUIRE)
 
-        self.merlin_set('TRIGGERSTART', '5')
-        self.merlin_set('NUMFRAMESPERTRIGGER', '1')
+        self.merlin_set('TRIGGERSTART', 5)
+        self.merlin_set('NUMFRAMESPERTRIGGER', 1)
         self.merlin_cmd('STARTACQUISITION')
 
         start = self.receive_data(nbytes=self.START_SIZE)
@@ -177,9 +177,9 @@ class CameraMerlin:
         elif exposure != self._soft_trigger_exposure:
             logger.info('Change exposure to %s s', exposure)
             self.setup_soft_trigger(exposure=exposure)
-        elif self._frame_number == self._frame_number_max:
+        elif self._frame_number == self.MAX_NUMFRAMESTOACQUIRE:
             logger.debug(('Maximum frame number reached for this acquisition, '
-                          'resetting soft trigger.') % self._frame_number_max)
+                          'resetting soft trigger.') % self.MAX_NUMFRAMESTOACQUIRE)
             self.setup_soft_trigger(exposure=exposure)
 
         self.merlin_cmd('SOFTTRIGGER')

--- a/instamatic/camera/camera_merlin.py
+++ b/instamatic/camera/camera_merlin.py
@@ -138,9 +138,9 @@ class CameraMerlin:
 
         self._frame_number = 0
 
-        # Set NUMFRAMESTOACQUIRE to a large number
-        # Merlin will only collect this number of frames with SOFTTRIGGER
-        self._frame_number_max = 10_000
+        # Set NUMFRAMESTOACQUIRE to maximum
+        # Merlin collects up to this number of frames with a single SOFTTRIGGER acquisition
+        self._frame_number_max = 42_949_672_950
         self.merlin_set('NUMFRAMESTOACQUIRE', self._frame_number_max)
 
         self.merlin_set('TRIGGERSTART', '5')

--- a/instamatic/camera/camera_merlin.py
+++ b/instamatic/camera/camera_merlin.py
@@ -140,7 +140,8 @@ class CameraMerlin:
 
         # Set NUMFRAMESTOACQUIRE to a large number
         # Merlin will only collect this number of frames with SOFTTRIGGER
-        self.merlin_set('NUMFRAMESTOACQUIRE', 10_000)
+        self._frame_number_max = 10_000
+        self.merlin_set('NUMFRAMESTOACQUIRE', self._frame_number_max)
 
         self.merlin_set('TRIGGERSTART', '5')
         self.merlin_set('NUMFRAMESPERTRIGGER', '1')
@@ -175,7 +176,10 @@ class CameraMerlin:
             self.setup_soft_trigger(exposure=exposure)
         elif exposure != self._soft_trigger_exposure:
             logger.info('Change exposure to %s s', exposure)
-            self.teardown_soft_trigger()
+            self.setup_soft_trigger(exposure=exposure)
+        elif self._frame_number == self._frame_number_max:
+            logger.debug(('Maximum frame number reached for this acquisition, '
+                          'resetting soft trigger.') % self._frame_number_max)
             self.setup_soft_trigger(exposure=exposure)
 
         self.merlin_cmd('SOFTTRIGGER')


### PR DESCRIPTION
Closes #75 

Todo:

- [x] When calling `cam.block()`, also reset the counter. -> not necessary, takes over a year to collect this number of frames with 1 ms exposure.
- [x] Find out what is the maximum frame number (bump number from 10k) -> uint32, 42949672950 according to the manual.
- [x] Test the code