### PR TITLE
Fixed typo in obj stig variable name.

### DIFF
--- a/src/instamatic/TEMController/simu_microscope.py
+++ b/src/instamatic/TEMController/simu_microscope.py
@@ -500,7 +500,7 @@ class SimuMicroscope:
         self.intermediatelensstigmator_y = y
 
     def getObjectiveLensStigmator(self) -> Tuple[int, int]:
-        return self.objectivelensstigmator_x, self.objectivelensstigmatir_y
+        return self.objectivelensstigmator_x, self.objectivelensstigmator_y
 
     def setObjectiveLensStigmator(self, x: int, y: int):
         self.objectivelensstigmator_x = x


### PR DESCRIPTION
There was a typo in the variable name for objective stigmator.
So it will throw exception when I call `getObjectiveLensStigmator` function.
So I fixed it.
`objectivelensstigmatir_y` => `objectivelensstigmator_y`