### PR TITLE
#86 Added setObjectiveLenseCoarse and setObjectiveLenseFine

### DIFF
--- a/src/instamatic/TEMController/fei_simu_microscope.py
+++ b/src/instamatic/TEMController/fei_simu_microscope.py
@@ -347,8 +347,14 @@ class FEISimuMicroscope:
     def getObjectiveLenseCoarse(self):
         return self.objectivelensecoarse_value
 
+    def setObjectiveLenseCoarse(self, value: int):
+        self.objectivelensecoarse_value = value
+
     def getObjectiveLenseFine(self):
         return self.objectivelensefine_value
+
+    def setObjectiveLenseFine(self, value: int):
+        self.objectivelensefine_value = value
 
     def getObjectiveMiniLens(self):
         return self.objectiveminilens_value

--- a/src/instamatic/TEMController/jeol_microscope.py
+++ b/src/instamatic/TEMController/jeol_microscope.py
@@ -522,10 +522,16 @@ class JeolMicroscope:
         value, result = self.lens3.GetOLc()
         return value
 
+    def setObjectiveLenseCoarse(self, value: int):
+        self.lens3.SetOLc(value)
+
     def getObjectiveLenseFine(self) -> int:
         # fine objective focus
         value, result = self.lens3.GetOLf()
         return value
+
+    def setObjectiveLenseFine(self, value: int):
+        self.lens3.SetOLf(value)
 
     def getObjectiveMiniLens(self) -> int:
         # no setter

--- a/src/instamatic/TEMController/simu_microscope.py
+++ b/src/instamatic/TEMController/simu_microscope.py
@@ -534,8 +534,14 @@ class SimuMicroscope:
     def getObjectiveLenseCoarse(self) -> int:
         return self.objectivelensecoarse_value
 
+    def setObjectiveLenseCoarse(self, value: int):
+        self.objectivelensecoarse_value = value
+
     def getObjectiveLenseFine(self) -> int:
         return self.objectivelensefine_value
+
+    def setObjectiveLenseFine(self, value: int):
+        self.objectivelensefine_value = value
 
     def getObjectiveMiniLens(self) -> int:
         return self.objectiveminilens_value


### PR DESCRIPTION
#86 Tested on JEOL 1400 microscope and confirmed that COM library actually supports these setter functions like `SetOLf` and `SetOLc`.
Did not test other functions, so not sure if other values also support setter functions in the COM library.