### PR TITLE
Tecnai bigfixes, Microscope client documentation and EAFP

### DIFF
--- a/src/instamatic/camera/camera_client.py
+++ b/src/instamatic/camera/camera_client.py
@@ -136,6 +136,8 @@ class CamClient:
 
         if response:
             status, data = loader(response)
+        else:
+            raise RuntimeError(f'Received empty response when evaluating {dct=}')
 
         if self.use_shared_memory and acquiring_image:
             data = self.get_data_from_shared_memory(**data)

--- a/src/instamatic/goniotool.py
+++ b/src/instamatic/goniotool.py
@@ -100,6 +100,8 @@ class GonioToolClient:
         response = self.s.recv(self._bufsize)
         if response:
             status, data = loader(response)
+        else:
+            raise RuntimeError(f'Received empty response when evaluating {dct=}')
 
         if status == 200:
             return data

--- a/src/instamatic/gui/ctrl_frame.py
+++ b/src/instamatic/gui/ctrl_frame.py
@@ -300,8 +300,8 @@ class ExperimentalCtrl(LabelFrame):
 
     def get_stage(self, event=None):
         x, y, _, _, _ = self.ctrl.stage.get()
-        self.var_stage_x.set(int(x))
-        self.var_stage_y.set(int(y))
+        self.var_stage_x.set(round(x))
+        self.var_stage_y.set(round(y))
 
     def start_alpha_wobbler(self):
         self.wobble_stop_event = threading.Event()

--- a/src/instamatic/gui/videostream_frame.py
+++ b/src/instamatic/gui/videostream_frame.py
@@ -191,7 +191,7 @@ class VideoStreamFrame(LabelFrame):
     def update_frametime(self, name, index, mode):
         # print name, index, mode
         try:
-            self.frametime = self.var_frametime.get()
+            self.frametime = self.var_frametime.get() or self.frametime
         except BaseException:
             pass
         else:

--- a/src/instamatic/microscope/base.py
+++ b/src/instamatic/microscope/base.py
@@ -82,6 +82,10 @@ class MicroscopeBase(ABC):
         pass
 
     @abstractmethod
+    def getScreenPosition(self) -> str:
+        pass
+
+    @abstractmethod
     def getSpotSize(self) -> int:
         pass
 
@@ -163,6 +167,10 @@ class MicroscopeBase(ABC):
 
     @abstractmethod
     def setObjectiveLensStigmator(self, x: int, y: int) -> None:
+        pass
+
+    @abstractmethod
+    def setScreenPosition(self, value: str) -> None:
         pass
 
     @abstractmethod

--- a/src/instamatic/microscope/client.py
+++ b/src/instamatic/microscope/client.py
@@ -2,13 +2,12 @@ from __future__ import annotations
 
 import atexit
 import datetime
-import json
-import pickle
 import socket
 import subprocess as sp
 import threading
 import time
 from functools import wraps
+from typing import Any, Callable
 
 from instamatic import config
 from instamatic.exceptions import TEMCommunicationError, exception_list
@@ -23,12 +22,12 @@ class ServerError(Exception):
     pass
 
 
-def kill_server(p):
+def kill_server(p: sp.Popen) -> None:
     # p.kill is not adequate
     sp.call(['taskkill', '/F', '/T', '/PID', str(p.pid)])
 
 
-def start_server_in_subprocess():
+def start_server_in_subprocess() -> None:
     cmd = 'instamatic.temserver.exe'
     p = sp.Popen(cmd, stdout=sp.DEVNULL)
     print(f'Starting TEM server ({HOST}:{PORT} on pid={p.pid})')
@@ -36,14 +35,18 @@ def start_server_in_subprocess():
 
 
 class MicroscopeClient:
-    """Simulates a Microscope object and synchronizes calls over a socket
-    server.
+    """
+    A proxy class for individual `Microscope` interface classes.
+    Simulates a `Microscope` object and synchronizes calls over a socket server.
+    On `__init__`, stores attributes of interfaced `Microscope` in `_dct`;
+    On `__getattr__`, wraps and returns an attribute of interfaced `Microscope`.
+    Thus, it is a surrogate for any `Microscope` class with a fitting interface.
 
-    For documentation, see the actual python interface to the microscope
-    API.
+    For documentation of individual methods,
+    see the actual python interface to the used microscope API.
     """
 
-    def __init__(self, *, interface: str):
+    def __init__(self, *, interface: str) -> None:
         super().__init__()
 
         self.interface = interface
@@ -74,12 +77,12 @@ class MicroscopeClient:
 
         atexit.register(self.s.close)
 
-    def connect(self):
+    def connect(self) -> None:
         self.s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         self.s.connect((HOST, PORT))
         print(f'Connected to TEM server ({HOST}:{PORT})')
 
-    def __getattr__(self, func_name):
+    def __getattr__(self, func_name: str) -> Callable:
         try:
             wrapped = self._dct[func_name]
         except KeyError as e:
@@ -94,7 +97,7 @@ class MicroscopeClient:
 
         return wrapper
 
-    def _eval_dct(self, dct):
+    def _eval_dct(self, dct: dict[str, Any]) -> Any:
         """Takes approximately 0.2-0.3 ms per call if HOST=='localhost'."""
         self.s.send(dumper(dct))
 
@@ -115,7 +118,7 @@ class MicroscopeClient:
         else:
             raise ConnectionError(f'Unknown status code: {status}')
 
-    def _init_dict(self):
+    def _init_dict(self) -> None:
         from instamatic.microscope import get_microscope_class
 
         tem = get_microscope_class(interface=self.interface)
@@ -124,10 +127,10 @@ class MicroscopeClient:
             key: value for key, value in tem.__dict__.items() if not key.startswith('_')
         }
 
-    def __dir__(self):
-        return self._dct.keys()
+    def __dir__(self) -> list:
+        return list(self._dct.keys())
 
-    def check_goniotool(self):
+    def check_goniotool(self) -> None:
         """Check whether goniotool is available and update the config as
         necessary."""
         if config.settings.use_goniotool:

--- a/src/instamatic/microscope/client.py
+++ b/src/instamatic/microscope/client.py
@@ -102,6 +102,8 @@ class MicroscopeClient:
 
         if response:
             status, data = loader(response)
+        else:
+            raise RuntimeError(f'Received empty response when evaluating {dct=}')
 
         if status == 200:
             return data

--- a/src/instamatic/microscope/client.py
+++ b/src/instamatic/microscope/client.py
@@ -35,8 +35,7 @@ def start_server_in_subprocess() -> None:
 
 
 class MicroscopeClient:
-    """
-    A proxy class for individual `Microscope` interface classes.
+    """A proxy class for individual `Microscope` interface classes.
     Simulates a `Microscope` object and synchronizes calls over a socket server.
     On `__init__`, stores attributes of interfaced `Microscope` in `_dct`;
     On `__getattr__`, wraps and returns an attribute of interfaced `Microscope`.

--- a/src/instamatic/microscope/client.py
+++ b/src/instamatic/microscope/client.py
@@ -35,14 +35,15 @@ def start_server_in_subprocess() -> None:
 
 
 class MicroscopeClient:
-    """A proxy class for individual `Microscope` interface classes.
-    Simulates a `Microscope` object and synchronizes calls over a socket server.
-    On `__init__`, stores attributes of interfaced `Microscope` in `_dct`;
-    On `__getattr__`, wraps and returns an attribute of interfaced `Microscope`.
-    Thus, it is a surrogate for any `Microscope` class with a fitting interface.
+    """A proxy class for individual `Microscope` interface classes. Simulates a
+    `Microscope` object and synchronizes calls over a socket server. On
+    `__init__`, stores attributes of interfaced `Microscope` in `_dct`; On
+    `__getattr__`, wraps and returns an attribute of interfaced `Microscope`.
+    Thus, it is a surrogate for any `Microscope` class with a fitting
+    interface.
 
-    For documentation of individual methods,
-    see the actual python interface to the used microscope API.
+    For documentation of individual methods, see the actual python
+    interface to the used microscope API.
     """
 
     def __init__(self, *, interface: str) -> None:

--- a/src/instamatic/microscope/interface/fei_microscope.py
+++ b/src/instamatic/microscope/interface/fei_microscope.py
@@ -505,3 +505,10 @@ class FEIMicroscope(MicroscopeBase):
 
     def setBrightness(self, value):
         self.tom.Illumination.IlluminatedAreaDiameter = value * 1e-6
+
+    def getScreenPosition(self) -> str:
+        raise NotImplementedError
+
+    def setScreenPosition(self, value: str) -> None:
+        raise NotImplementedError
+

--- a/src/instamatic/microscope/interface/fei_microscope.py
+++ b/src/instamatic/microscope/interface/fei_microscope.py
@@ -511,4 +511,3 @@ class FEIMicroscope(MicroscopeBase):
 
     def setScreenPosition(self, value: str) -> None:
         raise NotImplementedError
-

--- a/src/instamatic/microscope/interface/fei_microscope.py
+++ b/src/instamatic/microscope/interface/fei_microscope.py
@@ -167,19 +167,19 @@ class FEIMicroscope(MicroscopeBase):
         goniospeed = self.tom.Stage.Speed
 
         if x is not None:
-            pos.X = float(x * 1e-6)
+            pos.X = x * 1e-6
             axis += 1
         if y is not None:
-            pos.Y = float(y * 1e-6)
+            pos.Y = y * 1e-6
             axis += 2
         if z is not None:
-            pos.Z = float(z * 1e-6)
+            pos.Z = z * 1e-6
             axis += 4
         if a is not None:
-            pos.A = float(a / 180 * pi)
+            pos.A = a / 180 * pi
             axis += 8
         if b is not None:
-            pos.B = float(b / 180 * pi)
+            pos.B = b / 180 * pi
             axis += 16
 
         if speed == 1:

--- a/src/instamatic/microscope/interface/fei_microscope.py
+++ b/src/instamatic/microscope/interface/fei_microscope.py
@@ -167,19 +167,19 @@ class FEIMicroscope(MicroscopeBase):
         goniospeed = self.tom.Stage.Speed
 
         if x is not None:
-            pos.X = x * 1e-6
+            pos.X = float(x * 1e-6)
             axis += 1
         if y is not None:
-            pos.Y = y * 1e-6
+            pos.Y = float(y * 1e-6)
             axis += 2
         if z is not None:
-            pos.Z = z * 1e-6
+            pos.Z = float(z * 1e-6)
             axis += 4
         if a is not None:
-            pos.A = a / 180 * pi
+            pos.A = float(a / 180 * pi)
             axis += 8
         if b is not None:
-            pos.B = b / 180 * pi
+            pos.B = float(b / 180 * pi)
             axis += 16
 
         if speed == 1:

--- a/src/instamatic/server/cam_server.py
+++ b/src/instamatic/server/cam_server.py
@@ -125,11 +125,7 @@ class CamServer(threading.Thread):
         `attr_name` refers to a function, call it with *args and **kwargs."""
         # print(attr_name, args, kwargs)
         f = getattr(self.cam, attr_name)
-        if callable(f):
-            ret = f(*args, **kwargs)
-        else:
-            ret = f
-        return ret
+        return f(*args, **kwargs) if callable(f) else f
 
     def get_attrs(self):
         """Get attributes from cam object to update __dict__ on client side."""

--- a/src/instamatic/server/tem_server.py
+++ b/src/instamatic/server/tem_server.py
@@ -73,13 +73,12 @@ class TemServer(threading.Thread):
                 if self.verbose:
                     print(f'{now} | {status} {func_name}: {ret}')
 
-    def evaluate(self, func_name: str, args: list, kwargs: dict):
-        """Evaluate the function `func_name` on `self.tem` and call it with
-        `args` and `kwargs`."""
+    def evaluate(self, attr_name: str, args: list, kwargs: dict):
+        """Evaluate the function or attribute `attr_name` on `self.tem`, if
+        `attr_name` refers to a function, call it with *args and **kwargs."""
         # print(func_name, args, kwargs)
-        f = getattr(self.tem, func_name)
-        ret = f(*args, **kwargs)
-        return ret
+        f = getattr(self.tem, attr_name)
+        return f(*args, **kwargs) if callable(f) else f
 
 
 def handle(conn, q):


### PR DESCRIPTION
This PR encompasses a series of small bugs I have hitherto found when testing a FEI Tecnai / ASI Cheetah installation via the "Control" panel. Following @stefsmeets 's request from one pf the previous PRs, I am proposing that before suggesting fixes to two other large issues I found to keep things simpler:


### Major changes:

- [`MicroscopeClient`](https://github.com/instamatic-dev/instamatic/compare/main...Baharis:instamatic:control_frame_fix#diff-03dada3269050a76d32e4ce608e627052472dc795531d32b8b31d8e1d828545cR85-R86): When calling a method via `__getattr__`, try simply calling it via `_eval_dct` instead of raising `KeyError` if it is not found in the interface. Following python's "Easier to ask forgiveness than permission" philosophy, relying on the completeness of the interface can lead to issues described in issue #107, where a method is defined on the server but will not be called because the interface does not match the implementation. Instamatic's `MicroscopeServer` has already a transparent, elegant, built-in mechanism to catch and report errors.
  - Without this change, calling an "unregistered" method results in  ```AttributeError: `MicroscopeClient` object has no attribute `setScreenPosition` ``` – all while the method IS available.
  - With this change, both server and client report: `AttributeError: 'TecnaiMicroscope' object has no attribute 'setScreenPosition'`. Mind that in this case the error correctly points towards the `TecnaiMicroscope` implementation rather than `MicroscopeServer` proxy.

### Minor changes:

- [`MicroscopeClient`](https://github.com/instamatic-dev/instamatic/compare/main...Baharis:instamatic:control_frame_fix#diff-03dada3269050a76d32e4ce608e627052472dc795531d32b8b31d8e1d828545cR103-R104), [`CameraClient`](https://github.com/instamatic-dev/instamatic/compare/main...Baharis:instamatic:control_frame_fix#diff-e01fba028e89690b067fe127297efe4d5e005ef2b2f27e3acd2781957a93dd4c), [`GonioToolClient`](https://github.com/instamatic-dev/instamatic/compare/main...Baharis:instamatic:control_frame_fix#diff-35974a3e9182edeb4ea2c320402d6e96c879806b2ce8405281d1128a50f7ea4e): when server returns no response (can happen due to import error), catch `response==None` and raise explicit `RuntimeError` instead of allowing a misleading `UnboundLocalError` down the line;
- [`ExperimentalCtrl`](https://github.com/instamatic-dev/instamatic/compare/main...Baharis:instamatic:control_frame_fix#diff-978e6bff59390fa3b40630bfcaeb1496c7fe97e0b7e62f18494faf9fccd653c8): fix the fact that repeatedly setting and getting X/Y position of the stage can cause a gradual movement of the stage if it's position is given as float ( `int(6.99) = 6` -> set 6 -> get 5.99 -> `int(5.99) = 5`... )*.
- [`VideoStreamFrame`](https://github.com/instamatic-dev/instamatic/compare/main...Baharis:instamatic:control_frame_fix#diff-5bd979581d7af0ed48f0c59be4c98ab5e0ec9d9ee32c18e9a469fbae3220bf0d): when setting `frametime=0` in preview for even a split second, currently Java Exceptions are raised and connection to an ASI detector is broken; instead, use previous value rather than attempting to set a zero frametime.
- [`MicroscopeBase`](https://github.com/instamatic-dev/instamatic/compare/main...Baharis:instamatic:control_frame_fix#diff-a969943518bbe8ff52ad03fec4d02645320d7aa7323fa00921e6b9997678a525): In order to start instamatic, the microscope Interface of choice must implement `getScreenPosition` and `setScreenPosition`, so make them `@abstractmethod`s of the base class.
- [`FEIMicroscope`](https://github.com/instamatic-dev/instamatic/compare/main...Baharis:instamatic:control_frame_fix#diff-a676def3ac2951d9a5520054e25acbece960efbd7999239fc4512e1a05d7ffc6): Implement dummy `getScreenPosition` and `setScreenPosition` methods to comply with the newly-established required interface of the `BaseMicroscope`.
- [`TemServer`](https://github.com/instamatic-dev/instamatic/compare/main...Baharis:instamatic:control_frame_fix#diff-a982dc42f4a8996373d957e884df471a0eaadbb2f7b083733d2b21200bfc9f3e): Simplify `evaluate` method syntax and allow accessing non-callable attributes, just as one can in the case of `CamServer`. This is currently unused to the best of my knowledge, but there is no reason not to allow it.

### Documentation and maintainability:

- (Microscope) [`client.py`](https://github.com/instamatic-dev/instamatic/compare/main...Baharis:instamatic:control_frame_fix#diff-03dada3269050a76d32e4ce608e627052472dc795531d32b8b31d8e1d828545c): remove unused imports, add type hints, improve `MicroscopeClient` documentation.
- [`CamServer`](https://github.com/instamatic-dev/instamatic/compare/main...Baharis:instamatic:control_frame_fix#diff-bd743fbbf25e21633c705100736672424a3cc6c6e9f02ac968aecd581e224445): Simplify `evaluate` method syntax – this and `TemServer` changes are mostly cosmetic, feel free to reject them.

### Notes and roadmap

- \* The issue with `ExperimentalCtrl`'s `int` causing "sliding" is in fact a part of a bigger problem: in contrast to Jeol where instructions set value in nm, FEI and Tecnai assume distances in µm. However, based on my analysis instructions sent to either are identical. This meant that moving Joel gonio by 1 unit moves it by the width of ~3 gold atoms; however, moving FEI by 1 unit translates by 1µm! If I did not make a mistake here, this is a giant oversight that invalidate any chances of interoperability (same script does different things on different machines).
- Connected with the issue above but even more detrimental: running existing commands on Tecnai Microscope is completely impossible because some of them derive target values (e.g. beam or stage shifts) from numpy objects. Tecnai Server does not have access to numpy, and as such crashes whenever given `np.array([1, 2, 3])[0]` of type `np.int32`. Therefore, in my opinion, instamatic components should *enforce* format e.g. `instamatic/microscope/components/stage.py`'s `Stage.set` should IMO convert to `int` instead of only type-hinting. I can expand on that in a separate issue to explain that if you prefer.
- Another PR I could work on could in my opinion involve restructuring `instamatic/camera` similarly to how PR #99 restructured `instamatic/microscope` and generalize the `Server` classes that already at this point are mostly identical.