### PR TITLE
Generalize `get_binning` and fix low-hanging mypy issues

### DIFF
--- a/src/instamatic/camera/camera_base.py
+++ b/src/instamatic/camera/camera_base.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import List, Tuple
+from typing import List, Optional, Tuple
 
-from numpy import ndarray
+import numpy as np
 
 from instamatic import config
 
@@ -37,12 +37,21 @@ class CameraBase(ABC):
         pass
 
     @abstractmethod
-    def get_image(self, exposure: float = None, binsize: int = None, **kwargs) -> ndarray:
+    def get_image(
+        self,
+        exposure: Optional[float] = None,
+        binsize: Optional[int] = None,
+        **kwargs,
+    ) -> np.ndarray:
         pass
 
     def get_movie(
-        self, n_frames: int, exposure: float = None, binsize: int = None, **kwargs
-    ) -> List[ndarray]:
+        self,
+        n_frames: int,
+        exposure: Optional[float] = None,
+        binsize: Optional[int] = None,
+        **kwargs,
+    ) -> List[np.ndarray]:
         """Basic implementation, subclasses should override with appropriate
         optimization."""
         return [
@@ -50,11 +59,11 @@ class CameraBase(ABC):
             for _ in range(n_frames)
         ]
 
-    def __enter__(self):
+    def __enter__(self) -> CameraBase:
         self.establish_connection()
         return self
 
-    def __exit__(self, kind, value, traceback):
+    def __exit__(self, kind, value, traceback) -> None:
         self.release_connection()
 
     def get_binning(self) -> int:
@@ -66,7 +75,7 @@ class CameraBase(ABC):
     def get_name(self) -> str:
         return self.name
 
-    def load_defaults(self):
+    def load_defaults(self) -> None:
         if self.name != config.settings.camera:
             config.load_camera_config(camera_name=self.name)
         for key, val in config.camera.mapping.items():

--- a/src/instamatic/camera/camera_base.py
+++ b/src/instamatic/camera/camera_base.py
@@ -57,6 +57,9 @@ class CameraBase(ABC):
     def __exit__(self, kind, value, traceback):
         self.release_connection()
 
+    def get_binning(self) -> int:
+        return self.default_binsize
+
     def get_camera_dimensions(self) -> Tuple[int, int]:
         return self.dimensions
 

--- a/src/instamatic/camera/camera_client.py
+++ b/src/instamatic/camera/camera_client.py
@@ -5,6 +5,7 @@ import socket
 import subprocess as sp
 import time
 from functools import wraps
+from typing import Dict
 
 import numpy as np
 
@@ -79,7 +80,7 @@ class CamClient:
         )
         print('Use shared memory:', self.use_shared_memory)
 
-        self.buffers = {}
+        self.buffers: Dict[str, np.ndarray] = {}
         self.shms = {}
 
         self._init_dict()

--- a/src/instamatic/camera/camera_emmenu.py
+++ b/src/instamatic/camera/camera_emmenu.py
@@ -4,6 +4,7 @@ import atexit
 import logging
 import time
 from pathlib import Path
+from typing import Tuple
 
 import comtypes.client
 import numpy as np
@@ -347,19 +348,19 @@ class CameraEMMENU(CameraBase):
 
         return np.array(arr)
 
-    def get_camera_dimensions(self) -> (int, int):
+    def get_camera_dimensions(self) -> Tuple[int, int]:
         """Get the maximum dimensions reported by the camera."""
         # cfg = self.get_current_config()
         # return cfg.DimensionX, cfg.DimensionY
         return self._cam.RealSizeX, self._cam.RealSizeY
         # return self._cam.MaximumSizeX, self._cam.MaximumSizeY
 
-    def get_image_dimensions(self) -> (int, int):
+    def get_image_dimensions(self) -> Tuple[int, int]:
         """Get the dimensions of the image."""
         binning = self.get_binning()
         return int(self._cam.RealSizeX / binning), int(self._cam.RealSizeY / binning)
 
-    def get_physical_pixelsize(self) -> (int, int):
+    def get_physical_pixelsize(self) -> Tuple[int, int]:
         """Returns the physical pixel size of the camera nanometers."""
         return self._cam.PixelSizeX, self._cam.PixelSizeY
 

--- a/src/instamatic/camera/camera_gatan.py
+++ b/src/instamatic/camera/camera_gatan.py
@@ -18,6 +18,7 @@ from ctypes import (
     create_unicode_buffer,
 )
 from pathlib import Path
+from typing import Tuple
 
 import numpy as np
 
@@ -214,7 +215,7 @@ class CameraDLL(CameraBase):
         """Return the status of the camera."""
         return self._isCameraInfoAvailable()
 
-    def get_camera_dimensions(self) -> (int, int):
+    def get_camera_dimensions(self) -> Tuple[int, int]:
         """Return the dimensions reported by the camera."""
         pnWidth = c_int(0)
         pnHeight = c_int(0)

--- a/src/instamatic/camera/camera_gatan2.py
+++ b/src/instamatic/camera/camera_gatan2.py
@@ -5,6 +5,7 @@ import logging
 import sys
 import time
 from pathlib import Path
+from typing import Tuple
 
 import numpy as np
 
@@ -44,13 +45,13 @@ class CameraGatan2(CameraBase):
         """Get the version number of DM."""
         return self.g.GetDMVersion()
 
-    def get_image_dimensions(self) -> (int, int):
+    def get_image_dimensions(self) -> Tuple[int, int]:
         """Get the dimensions of the image."""
         binning = self.get_binning()
         dim_x, dim_y = self.get_camera_dimensions()
         return int(dim_x / binning), int(dim_y / binning)
 
-    def get_physical_pixelsize(self) -> (int, int):
+    def get_physical_pixelsize(self) -> Tuple[int, int]:
         """Returns the physical pixel size of the camera nanometers."""
         raise NotImplementedError
 

--- a/src/instamatic/camera/camera_merlin.py
+++ b/src/instamatic/camera/camera_merlin.py
@@ -29,7 +29,7 @@ import atexit
 import logging
 import socket
 import time
-from typing import Any, List
+from typing import Any, List, Tuple
 
 import numpy as np
 
@@ -337,7 +337,7 @@ class CameraMerlin(CameraBase):
 
         return data
 
-    def get_image_dimensions(self) -> (int, int):
+    def get_image_dimensions(self) -> Tuple[int, int]:
         """Get the binned dimensions reported by the camera."""
         binning = self.get_binning()
         dim_x, dim_y = self.get_camera_dimensions()

--- a/src/instamatic/camera/camera_serval.py
+++ b/src/instamatic/camera/camera_serval.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import atexit
 import logging
 from pathlib import Path
+from typing import Tuple
 
 import numpy as np
 from serval_toolkit.camera import Camera as ServalCamera
@@ -92,7 +93,7 @@ class CameraServal(CameraBase):
 
         return arr
 
-    def get_image_dimensions(self) -> (int, int):
+    def get_image_dimensions(self) -> Tuple[int, int]:
         """Get the binned dimensions reported by the camera."""
         binning = self.get_binning()
         dim_x, dim_y = self.get_camera_dimensions()

--- a/src/instamatic/camera/camera_simu.py
+++ b/src/instamatic/camera/camera_simu.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import atexit
 import logging
 import time
+from typing import List, Optional, Tuple
 
 import numpy as np
 
@@ -66,7 +67,14 @@ class CameraSimu(CameraBase):
 
         return arr
 
-    def get_movie(self, n_frames, *, exposure: float = None, binsize: int = None, **kwargs):
+    def get_movie(
+        self,
+        n_frames: int,
+        *,
+        exposure: Optional[float] = None,
+        binsize: Optional[int] = None,
+        **kwargs,
+    ) -> List[np.ndarray]:
         """Movie acquisition routine. If the exposure and binsize are not
         given, the default values are read from the config file.
 
@@ -93,7 +101,7 @@ class CameraSimu(CameraBase):
         """Check if the camera is available."""
         return True
 
-    def get_image_dimensions(self) -> (int, int):
+    def get_image_dimensions(self) -> Tuple[int, int]:
         """Get the binned dimensions reported by the camera."""
         binning = self.get_binning()
         dim_x, dim_y = self.get_camera_dimensions()

--- a/src/instamatic/camera/camera_simu.py
+++ b/src/instamatic/camera/camera_simu.py
@@ -170,9 +170,6 @@ class CameraSimu(CameraBase):
     def get_timestamps(self, start_index, end_index):
         return list(range(20))
 
-    def get_binning(self):
-        return self.default_binsize
-
     def write_tiffs(
         self, start_index: int, stop_index: int, path: str, clear_buffer=True
     ) -> None:

--- a/src/instamatic/microscope/components/stage.py
+++ b/src/instamatic/microscope/components/stage.py
@@ -283,6 +283,10 @@ class Stage:
             delay between movements in seconds to allow the stage to settle
         """
         wait = True
+        current_x, current_y = self.xy
+        x = current_x if x is None else x
+        y = current_y if y is None else y
+
         self.set(x=x - step, y=y - step)
         if settle_delay:
             time.sleep(settle_delay)

--- a/src/instamatic/microscope/microscope.py
+++ b/src/instamatic/microscope/microscope.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Optional
+
 from instamatic import config
 from instamatic.microscope.base import MicroscopeBase
 
@@ -32,7 +34,7 @@ def get_microscope_class(interface: str) -> 'type[MicroscopeBase]':
     return cls
 
 
-def get_microscope(name: str = None, use_server: bool = False) -> MicroscopeBase:
+def get_microscope(name: Optional[str] = None, use_server: bool = False) -> MicroscopeBase:
     """Generic class to load microscope interface class.
 
     name: str

--- a/src/instamatic/tools.py
+++ b/src/instamatic/tools.py
@@ -4,6 +4,7 @@ import glob
 import os
 import sys
 from pathlib import Path
+from typing import Tuple
 
 import numpy as np
 from scipy import interpolate, ndimage
@@ -70,7 +71,7 @@ def to_xds_untrusted_area(kind: str, coords: list) -> str:
         raise ValueError('Only quadrilaterals are supported for now')
 
 
-def find_subranges(lst: list) -> (int, int):
+def find_subranges(lst: list) -> Tuple[int, int]:
     """Takes a range of sequential numbers (possibly with gaps) and splits them
     in sequential sub-ranges defined by the minimum and maximum value."""
     from itertools import groupby


### PR DESCRIPTION
As in the title. I am working on something bigger – Serval raises on `get_image(exposure=0)` and it wrecks havoc when trying to collect any images other than preview – but apparently I am on a mission to bother @stefsmeets at least weekly, so here are two tiny improvements to the code base from this week:

- Define `CameraBase.get_binning`: controller needs it but some cameras (including Serval) do not define it;
- Fix some straightforward `mypy` issue, mostly `(int, int)`s that are not understood correctly and should be `Tuple[int, int]` instead.

Notes:

- `CameraSimu.get_binning` was removed as it was effectively upgraded to the new `CameraBase.get_binning` and `CameraSimu` inherits from `CameraBase`;
- `CameraGatan2.get_binning` explicitly does `raise NotImplementedError` and I did not know whether this is intentional or not so I left it be. I believe it should work as normal though, given all example detector config files do contain `default_binning` used in inherited `CameraBase`'s definition.