### PR TITLE
Improve ASI detector support and reduce excessive logging

### DIFF
--- a/THANKS.md
+++ b/THANKS.md
@@ -1,7 +1,7 @@
 Code contributors
 -----------------
 
-See [Github contributors list](https://github.com/nipy/nipype/graphs/contributors)
+See [Github contributors list](https://github.com/instamatic-dev/instamatic/graphs/contributors)
 
 Special thanks
 --------------

--- a/src/instamatic/camera/camera_serval.py
+++ b/src/instamatic/camera/camera_serval.py
@@ -71,7 +71,7 @@ class CameraServal(CameraBase):
         n: int = 1 if n_triggers is Ignore else n_triggers
         e: float = self.default_exposure if exposure is None else exposure
 
-        if n_triggers == 0:  # single image is communicated via n_triggers = None
+        if n_triggers == 0:  # single image is communicated via n_triggers = Ignore
             return []
 
         elif e < self.MIN_EXPOSURE:

--- a/src/instamatic/camera/camera_serval.py
+++ b/src/instamatic/camera/camera_serval.py
@@ -31,6 +31,15 @@ class CameraServal(CameraBase):
         logger.info(f'Camera {self.get_name()} initialized')
         atexit.register(self.release_connection)
 
+    def _validate_exposure(self, exposure: float) -> float:
+        if exposure < 0.001:
+            logger.warning(f'Exposure {exposure} too low. Adjusting to 0.001s')
+            exposure = 0.001
+        elif exposure > 10:
+            logger.warning(f'Exposure {exposure} too high. Adjusting to 10s')
+            exposure = 10
+        return exposure
+
     def get_image(self, exposure=None, binsize=None, **kwargs) -> np.ndarray:
         """Image acquisition routine. If the exposure and binsize are not
         given, the default values are read from the config file.
@@ -42,6 +51,7 @@ class CameraServal(CameraBase):
         """
         if exposure is None:
             exposure = self.default_exposure
+        exposure = self._validate_exposure(exposure)
 
         # Upload exposure settings (Note: will do nothing if no change in settings)
         self.conn.set_detector_config(
@@ -77,6 +87,7 @@ class CameraServal(CameraBase):
             exposure = self.default_exposure
         if not binsize:
             binsize = self.default_binsize
+        exposure = self._validate_exposure(exposure)
 
         self.conn.set_detector_config(TriggerMode='CONTINUOUS')
 

--- a/src/instamatic/camera/camera_serval.py
+++ b/src/instamatic/camera/camera_serval.py
@@ -68,7 +68,7 @@ class CameraServal(CameraBase):
         if exposure is None:
             exposure = self.default_exposure
         if exposure < self.MIN_EXPOSURE:
-            logger.warning(f'{self.BAD_EXPOSURE_MSG}: {exposure}')
+            logger.warning('%s: %d', self.BAD_EXPOSURE_MSG, exposure)
             return self._get_image_null()
         elif self.MIN_EXPOSURE <= exposure <= self.MAX_EXPOSURE:
             return self._get_image_single(exposure, binsize, **kwargs)

--- a/src/instamatic/camera/camera_serval.py
+++ b/src/instamatic/camera/camera_serval.py
@@ -95,7 +95,7 @@ class CameraServal(CameraBase):
         arr = self.conn.get_images(
             nTriggers=n_frames,
             ExposureTime=exposure,
-            TriggerPeriod=exposure + self.exposure_cooldown,
+            TriggerPeriod=exposure,
         )
 
         return arr

--- a/src/instamatic/camera/camera_serval.py
+++ b/src/instamatic/camera/camera_serval.py
@@ -114,7 +114,7 @@ class CameraServal(CameraBase):
         images = self.conn.get_image_stream(nTriggers=n_frames, disable_tqdm=True)
         self.conn.measurement_stop()
         self.conn.set_detector_config(**previous_config)
-        return images
+        return [np.array(image) for image in images]
 
     def get_image_dimensions(self) -> Tuple[int, int]:
         """Get the binned dimensions reported by the camera."""

--- a/src/instamatic/camera/camera_serval.py
+++ b/src/instamatic/camera/camera_serval.py
@@ -70,9 +70,10 @@ class CameraServal(CameraBase):
         if exposure < self.MIN_EXPOSURE:
             logger.warning('%s: %d', self.BAD_EXPOSURE_MSG, exposure)
             return self._get_image_null()
-        elif self.MIN_EXPOSURE <= exposure <= self.MAX_EXPOSURE:
+        elif exposure > self.MAX_EXPOSURE:
+            ...
+        else:
             return self._get_image_single(exposure, binsize, **kwargs)
-        else:  # if exposure > self.MAX_EXPOSURE
             logger.warning(f'{self.BAD_EXPOSURE_MSG}: {exposure}')
             n_triggers = math.ceil(exposure / self.MAX_EXPOSURE)
             exposure1 = (exposure + self.dead_time) / n_triggers - self.dead_time

--- a/src/instamatic/camera/videostream.py
+++ b/src/instamatic/camera/videostream.py
@@ -126,9 +126,6 @@ class VideoStream(threading.Thread):
         return grabber
 
     def get_image(self, exposure=None, binsize=None):
-        current_frametime = self.grabber.frametime
-
-        # set to 0 to prevent it lagging data acquisition
         self.block()  # Stop the passive collection during single-frame acquisition
         if exposure:
             self.grabber.exposure = exposure

--- a/src/instamatic/camera/videostream.py
+++ b/src/instamatic/camera/videostream.py
@@ -80,8 +80,7 @@ class MediaGrabber:
                 self.callback(media, request=r)
 
             elif not self.continuousCollectionEvent.is_set():
-                b = self.default_binsize
-                frame = self.cam.get_image(exposure=self.frametime, binsize=b)
+                frame = self.cam.get_image(exposure=self.frametime, binsize=self.default_binsize)
                 self.callback(frame, request=None)
 
     def start_loop(self):

--- a/src/instamatic/camera/videostream.py
+++ b/src/instamatic/camera/videostream.py
@@ -24,7 +24,7 @@ class ImageRequest(MediaRequest):
 
 
 class MovieRequest(MediaRequest):
-    """To be used when requesting a single image via `get_image`"""
+    """To be used when requesting an image series via `get_movie`"""
 
 
 class MediaGrabber:
@@ -80,7 +80,9 @@ class MediaGrabber:
                 self.callback(media, request=r)
 
             elif not self.continuousCollectionEvent.is_set():
-                frame = self.cam.get_image(exposure=self.frametime, binsize=self.default_binsize)
+                frame = self.cam.get_image(
+                    exposure=self.frametime, binsize=self.default_binsize
+                )
                 self.callback(frame, request=None)
 
     def start_loop(self):

--- a/src/instamatic/camera/videostream.py
+++ b/src/instamatic/camera/videostream.py
@@ -154,6 +154,7 @@ class VideoStream(threading.Thread):
         self.grabber.acquireCompleteEvent.wait()
         with self.grabber.lock:
             image = self.acquired_media
+        self.grabber.request = None
         self.grabber.acquireCompleteEvent.clear()
         self.unblock()  # Resume the passive collection
         return image
@@ -167,6 +168,7 @@ class VideoStream(threading.Thread):
         self.grabber.acquireCompleteEvent.wait()
         with self.grabber.lock:
             movie = self.acquired_media
+        self.grabber.request = None
         self.grabber.acquireCompleteEvent.clear()
         self.unblock()  # Resume the passive collection
         return movie

--- a/src/instamatic/camera/videostream.py
+++ b/src/instamatic/camera/videostream.py
@@ -129,7 +129,7 @@ class VideoStream(threading.Thread):
         current_frametime = self.grabber.frametime
 
         # set to 0 to prevent it lagging data acquisition
-        self.grabber.frametime = 0
+        self.block()  # Stop the passive collection during single-frame acquisition
         if exposure:
             self.grabber.exposure = exposure
         if binsize:
@@ -144,7 +144,7 @@ class VideoStream(threading.Thread):
         self.grabber.lock.release()
 
         self.grabber.acquireCompleteEvent.clear()
-        self.grabber.frametime = current_frametime
+        self.unblock()  # Resume the passive collection
         return frame
 
     def update_frametime(self, frametime):

--- a/src/instamatic/config/camera/serval.yaml
+++ b/src/instamatic/config/camera/serval.yaml
@@ -1,21 +1,40 @@
 camera_rotation_vs_stage_xy: 0.0
 default_binsize: 1
 default_exposure: 0.02
+
+# Double-check that your dimensions match the ones from your detector.
 dimensions: [512, 512]
+
 dynamic_range: 11800
 interface: serval
+
 physical_pixelsize: 0.055
 possible_binsizes: [1]
+
 stretch_amplitude: 0.0
 stretch_azimuth: 0.0
+
+# This configuration can be tuned based on your needs. 
+# Please refer to the Serval manual.
+# For Serval 3.3.x, it is in section 4.5.7 - Detector Config JSON structure.
 detector_config:
   BiasVoltage: 100
   BiasEnabled: True
   TriggerMode: SOFTWARESTART_TIMERSTOP
   ExposureTime: 1.0
-  TriggerPeriod: 1.001
+  TriggerPeriod: 1.002
   nTriggers: 1000000000
-  GainMode: HGM
+  # Remove the following lines if you are using CheeTah T3 variants (timepix3), 
+  # as they do not support these settings.
+  GainMode: HGM # Only for Medipix3
+  PixelDepth: 24 # Set to 12 for 12-bit (normal) mode - only Medipix3
+  BothCounters: True # Set to False for 12-bit mode - only Medipix3
+
+# Change this to the location of your actual factory settings
 bpc_file_path: '/home/asi/Desktop/Factory_settings/SPM-HGM/config.bpc'
 dacs_file_path: '/home/asi/Desktop/Factory_settings/SPM-HGM/config.dacs'
 url: 'http://localhost:8080'
+
+# The ASIC ("chip") that the camera uses.
+# Use "medipix3" for CheeTah M3 variants and "timepix3" for CheeTah T3 variants.
+asic: medipix3

--- a/src/instamatic/config/camera/serval.yaml
+++ b/src/instamatic/config/camera/serval.yaml
@@ -20,7 +20,7 @@ stretch_azimuth: 0.0
 detector_config:
   BiasVoltage: 100
   BiasEnabled: True
-  TriggerMode: SOFTWARESTART_TIMERSTOP
+  TriggerMode: SOFTWARESTART_TIMERSTOP  # Currently only this mode is supported
   ExposureTime: 1.0
   TriggerPeriod: 1.002
   nTriggers: 1000000000

--- a/src/instamatic/config/camera/serval.yaml
+++ b/src/instamatic/config/camera/serval.yaml
@@ -22,9 +22,12 @@ detector_config:
   BiasEnabled: True
   TriggerMode: SOFTWARESTART_TIMERSTOP
   ExposureTime: 1.0
-  TriggerPeriod: 1.002  # Try 1.0005 for Medipix3
+  TriggerPeriod: 1.002
   nTriggers: 1000000000
-  # Disregard the following lines if you are using CheeTah T3 variants (timepix3),
+  # TriggerPeriod and ExposureTime are used to derive the dead/cooldown
+  # time of the detector. Consult Serval user manual to determine
+  # the optimal cooldown time for requested TriggerMode on your detector.
+  # Remove the following lines if you are using CheeTah T3 variants (timepix3),
   # as they do not support these settings.
   GainMode: HGM # Only for Medipix3
   PixelDepth: 24 # Set to 12 for 12-bit (normal) mode - only Medipix3

--- a/src/instamatic/config/camera/serval.yaml
+++ b/src/instamatic/config/camera/serval.yaml
@@ -14,7 +14,7 @@ possible_binsizes: [1]
 stretch_amplitude: 0.0
 stretch_azimuth: 0.0
 
-# This configuration can be tuned based on your needs. 
+# This configuration can be tuned based on your needs.
 # Please refer to the Serval manual.
 # For Serval 3.3.x, it is in section 4.5.7 - Detector Config JSON structure.
 detector_config:
@@ -24,7 +24,7 @@ detector_config:
   ExposureTime: 1.0
   TriggerPeriod: 1.002
   nTriggers: 1000000000
-  # Remove the following lines if you are using CheeTah T3 variants (timepix3), 
+  # Disregard the following lines if you are using CheeTah T3 variants (timepix3),
   # as they do not support these settings.
   GainMode: HGM # Only for Medipix3
   PixelDepth: 24 # Set to 12 for 12-bit (normal) mode - only Medipix3

--- a/src/instamatic/config/camera/serval.yaml
+++ b/src/instamatic/config/camera/serval.yaml
@@ -34,7 +34,3 @@ detector_config:
 bpc_file_path: '/home/asi/Desktop/Factory_settings/SPM-HGM/config.bpc'
 dacs_file_path: '/home/asi/Desktop/Factory_settings/SPM-HGM/config.dacs'
 url: 'http://localhost:8080'
-
-# The ASIC ("chip") that the camera uses.
-# Use "medipix3" for CheeTah M3 variants and "timepix3" for CheeTah T3 variants.
-asic: medipix3

--- a/src/instamatic/config/camera/serval.yaml
+++ b/src/instamatic/config/camera/serval.yaml
@@ -22,13 +22,13 @@ detector_config:
   BiasEnabled: True
   TriggerMode: SOFTWARESTART_TIMERSTOP
   ExposureTime: 1.0
-  TriggerPeriod: 1.002
+  TriggerPeriod: 1.002  # Try 1.0005 for Medipix3
   nTriggers: 1000000000
   # Disregard the following lines if you are using CheeTah T3 variants (timepix3),
   # as they do not support these settings.
   GainMode: HGM # Only for Medipix3
   PixelDepth: 24 # Set to 12 for 12-bit (normal) mode - only Medipix3
-  BothCounters: True # Set to False for 12-bit mode - only Medipix3
+  BothCounters: False # Set to True for 12-bit mode - only Medipix3
 
 # Change this to the location of your actual factory settings
 bpc_file_path: '/home/asi/Desktop/Factory_settings/SPM-HGM/config.bpc'

--- a/src/instamatic/experiments/cred/experiment.py
+++ b/src/instamatic/experiments/cred/experiment.py
@@ -83,7 +83,8 @@ class Experiment(ExperimentBase):
         self.unblank_beam = unblank_beam
         self.logger = log
         self.mode = mode
-        if ctrl.cam.name == 'simulate':
+        # we need to be able to simulate using the serval camera as well - add "simulate" to part of the name.
+        if 'simulate' in ctrl.cam.name:
             self.mode = 'simulate'
         self.stopEvent = stop_event
         self.flatfield = flatfield

--- a/src/instamatic/gui/about_frame.py
+++ b/src/instamatic/gui/about_frame.py
@@ -4,7 +4,7 @@ from tkinter import *
 from tkinter import Label as tkLabel
 from tkinter.font import Font, nametofont
 from tkinter.ttk import *
-from typing import Callable
+from typing import Callable, Optional
 
 import instamatic
 
@@ -32,7 +32,9 @@ def get_background_of_widget(widget):
 
 class Copyable(Text):
     def __init__(self, master=None, text: str = '', **kwargs) -> None:
-        kwargs = {**kwargs, 'bg': get_background_of_widget(master), 'relief': 'flat'}
+        kwargs['bg'] = kwargs.get('bg', get_background_of_widget(master))
+        kwargs['relief'] = kwargs.get('relief', 'flat')
+        kwargs['width'] = kwargs.get('width', len(text))
         super().__init__(master, **kwargs)
         self.insert(1.0, text)
         self.configure(state='disabled', font=nametofont('TkDefaultFont'))

--- a/src/instamatic/gui/about_frame.py
+++ b/src/instamatic/gui/about_frame.py
@@ -4,6 +4,7 @@ from tkinter import *
 from tkinter import Label as tkLabel
 from tkinter.font import Font, nametofont
 from tkinter.ttk import *
+from typing import Callable
 
 import instamatic
 
@@ -27,6 +28,14 @@ def get_background_of_widget(widget):
         background = Style().lookup(style, 'background')
 
     return background
+
+
+class Copyable(Text):
+    def __init__(self, master=None, text: str = '', **kwargs) -> None:
+        kwargs = {**kwargs, 'bg': get_background_of_widget(master), 'relief': 'flat'}
+        super().__init__(master, **kwargs)
+        self.insert(1.0, text)
+        self.configure(state='disabled', font=nametofont('TkDefaultFont'))
 
 
 class Link_Button(tkLabel):
@@ -110,45 +119,43 @@ class AboutFrame(LabelFrame):
 
         Label(frame, text='').grid(row=0, column=0, sticky='W')
         Label(frame, text='Contact:').grid(row=1, column=0, sticky='W', padx=10)
-        Label(frame, text=f'{instamatic.__author__} ({instamatic.__author_email__}').grid(
-            row=1, column=1, sticky='W'
-        )
+        auth = f'{instamatic.__author__}, {instamatic.__author_email__}'
+        Copyable(frame, text=auth, height=1).grid(row=1, column=1, sticky='W')
         Label(frame, text='').grid(row=5, column=0, sticky='W')
 
         Label(frame, text='Source code:').grid(row=10, column=0, sticky='W', padx=10)
-        link = Link_Button(frame, text=instamatic.__url__, action=self.link_github)
+        action = self.link_action_factory(url=instamatic.__url__)
+        link = Link_Button(frame, text=instamatic.__url__, action=action)
         link.grid(row=10, column=1, sticky='W')
         Label(frame, text='').grid(row=12, column=0, sticky='W')
 
         Label(frame, text='Docs:').grid(row=20, column=0, sticky='W', padx=10)
-        link = Link_Button(frame, text=instamatic.__docs__, action=self.link_github)
+        action = self.link_action_factory(url=instamatic.__docs__)
+        link = Link_Button(frame, text=instamatic.__docs__, action=action)
         link.grid(row=20, column=1, sticky='W')
         Label(frame, text='').grid(row=22, column=0, sticky='W')
 
         Label(frame, text='Bugs:').grid(row=30, column=0, sticky='W', padx=10)
-        link = Link_Button(frame, text=instamatic.__issues__, action=self.link_github)
+        action = self.link_action_factory(url=instamatic.__issues__)
+        link = Link_Button(frame, text=instamatic.__issues__, action=action)
         link.grid(row=30, column=1, sticky='W')
         Label(frame, text='').grid(row=32, column=0, sticky='W')
 
         Label(frame, text='If you found this software useful, please cite:').grid(
             row=40, column=0, sticky='W', columnspan=2, padx=10
         )
-        txt = Message(frame, text=instamatic.__citation__, width=320, justify=LEFT)
-        txt.grid(row=41, column=1, sticky='W')
-
-        Label(frame, text='').grid(row=41, column=0, sticky='W', padx=10)
+        txt = Copyable(frame, text=instamatic.__citation__, height=1)
+        txt.grid(row=41, column=0, columnspan=2, sticky='W', padx=10)
 
         frame.pack(side='top', fill='x')
 
-    def link_github(self, event=None):
-        import webbrowser
+    def link_action_factory(self, url: str) -> Callable:
+        def link_action(event=None) -> None:
+            import webbrowser
 
-        webbrowser.open_new(instamatic.__url__)
+            webbrowser.open_new(url)
 
-    def link_manual(self, event=None):
-        import webbrowser
-
-        webbrowser.open_new(instamatic.__url__)
+        return link_action
 
 
 module = BaseModule(name='about', display_name='about', tk_frame=AboutFrame, location='bottom')
@@ -157,5 +164,5 @@ commands = {}
 
 if __name__ == '__main__':
     root = Tk()
-    About(root).pack(side='top', fill='both', expand=True)
+    AboutFrame(root).pack(side='top', fill='both', expand=True)
     root.mainloop()

--- a/src/instamatic/gui/gui.py
+++ b/src/instamatic/gui/gui.py
@@ -157,6 +157,9 @@ class MainFrame:
         self.root.bind('<Escape>', self.close)
 
     def close(self):
+        # Prevent tk from trying to write into a closed `console_frame:Writer`
+        sys.stdout = sys.__stdout__
+        sys.stderr = sys.__stderr__
         try:
             self.stream_frame.close()
         except AttributeError:

--- a/src/instamatic/main.py
+++ b/src/instamatic/main.py
@@ -6,6 +6,7 @@ import os
 import pprint
 import sys
 from pathlib import Path
+from typing import Callable
 
 import instamatic
 from instamatic import config
@@ -120,9 +121,10 @@ def main():
     parser.add_argument(
         '-v',
         '--verbose',
-        action='store_true',
-        dest='verbose',
-        help="Show imported packages' DEBUG records in log",
+        action='count',
+        dest='verbosity',
+        help='Write debug messages of instamatic (-v) and other imported packages (-vv) to the log',
+        default=0,
     )
 
     parser.set_defaults(
@@ -163,20 +165,25 @@ def main():
     date = datetime.datetime.now().strftime('%Y-%m-%d')
     logfile = config.locations['logs'] / f'instamatic_{date}.log'
 
-    def filter_out_imported_package_debug_records(r: logging.LogRecord) -> bool:
-        return (
-            r.name.startswith('instamatic')
-            or r.name == '__main__'
-            or r.levelno > logging.DEBUG
-            or options.verbose
-        )
+    def log_filter_factory(verbosity: int) -> Callable[[logging.LogRecord], bool]:
+        instamatic_logging_level = logging.DEBUG if verbosity >= 1 else logging.INFO
+        imported_logging_level = logging.DEBUG if verbosity >= 2 else logging.INFO
+
+        def log_filter_function(r: logging.LogRecord) -> bool:
+            if r.name.startswith('instamatic') or r.name == '__main__':
+                return r.levelno >= instamatic_logging_level
+            else:
+                return r.levelno >= imported_logging_level
+
+        return log_filter_function
 
     log_main = logging.getLogger()
     log_main.setLevel(logging.DEBUG)
-    log_format = '%(asctime)s | %(module)s:%(lineno)s | %(levelname)s | %(message)s'
+    log_detail = 'module' if options.verbose <= 2 else 'pathname'
+    log_format = f'%(asctime)s | %({log_detail})s:%(lineno)s | %(levelname)s | %(message)s'
     log_handler = logging.FileHandler(logfile)
     log_handler.setFormatter(logging.Formatter(log_format))
-    log_handler.addFilter(filter_out_imported_package_debug_records)
+    log_handler.addFilter(log_filter_factory(verbosity=options.verbosity))
     log_main.addHandler(log_handler)
 
     logging.captureWarnings(True)

--- a/src/instamatic/main.py
+++ b/src/instamatic/main.py
@@ -164,8 +164,12 @@ def main():
     logfile = config.locations['logs'] / f'instamatic_{date}.log'
 
     def filter_out_imported_package_debug_records(r: logging.LogRecord) -> bool:
-        return (r.name.startswith("instamatic") or r.name == "__main__"
-                or r.levelno > logging.DEBUG or options.verbose)
+        return (
+            r.name.startswith('instamatic')
+            or r.name == '__main__'
+            or r.levelno > logging.DEBUG
+            or options.verbose
+        )
 
     log_main = logging.getLogger()
     log_main.setLevel(logging.DEBUG)

--- a/src/instamatic/main.py
+++ b/src/instamatic/main.py
@@ -122,7 +122,7 @@ def main():
         '-v',
         '--verbose',
         action='count',
-        dest='verbosity',
+        dest='verbose',
         help='Write debug messages of instamatic (-v) and other imported packages (-vv) to the log',
         default=0,
     )
@@ -183,7 +183,7 @@ def main():
     log_format = f'%(asctime)s | %({log_detail})s:%(lineno)s | %(levelname)s | %(message)s'
     log_handler = logging.FileHandler(logfile)
     log_handler.setFormatter(logging.Formatter(log_format))
-    log_handler.addFilter(log_filter_factory(verbosity=options.verbosity))
+    log_handler.addFilter(log_filter_factory(verbosity=options.verbose))
     log_main.addHandler(log_handler)
 
     logging.captureWarnings(True)

--- a/src/instamatic/server/tem_server.py
+++ b/src/instamatic/server/tem_server.py
@@ -1,9 +1,7 @@
 from __future__ import annotations
 
 import datetime
-import json
 import logging
-import pickle
 import queue
 import socket
 import threading
@@ -11,8 +9,7 @@ import traceback
 
 from instamatic import config
 from instamatic.microscope import get_microscope
-
-from .serializer import dumper, loader
+from instamatic.server.serializer import dumper, loader
 
 condition = threading.Condition()
 box = []

--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -41,6 +41,31 @@ def test_get_image(ctrl):
     assert y1 == bin4 * y4
 
 
+def test_get_movie(ctrl):
+    bin1 = 1
+    bin2 = 2
+    bin4 = 4
+
+    movie = ctrl.get_movie(n_frames=bin1, binsize=bin1)
+    x1, y1 = movie[0].shape
+    l1 = len(movie)
+
+    movie = ctrl.get_movie(n_frames=bin2, binsize=bin2)
+    x2, y2 = movie[0].shape
+    l2 = len(movie)
+
+    movie = ctrl.get_movie(n_frames=bin4, binsize=bin4)
+    x4, y4 = movie[0].shape
+    l4 = len(movie)
+
+    assert x1 == bin2 * x2
+    assert y1 == bin2 * y2
+    assert l1 * bin2 == l2
+    assert x1 == bin4 * x4
+    assert y1 == bin4 * y4
+    assert l1 * bin4 == l4
+
+
 def test_functions(ctrl):
     dims = ctrl.cam.get_image_dimensions()
     assert isinstance(dims, tuple)


### PR DESCRIPTION
### The context

This week I worked on adapting Instamatic to our ASI Medipix3 detector via the `CameraServal` class. Despite variety of issues, many of them boiled to the same problems. Actions listed below led to GUI crashing:

1) Setting exposure > 10 seconds;
2) Setting exposure ≤ 0 seconds;
3) Collecting any images other than the preview;
4) Starting the GUI with default config.

AD 1 & 2, I learned to my surprise that both ASI Medipix3 and Timepix3 impose hard limits on exposure: >0, ≤10 seconds. ~~I have therefore added a validate method to `CameraServal` that trims any exposure passed to a [0.001, 10] range and logs a warning. If anything requests 20-second frame, it will receive a 10-second frame after approx. 10.2 seconds. It is neither pretty nor general but it gets the job done and fixes 99% of issues.~~

EDIT: After reviewing and consulting this issue, instead of trimming the values to the limits, I have implemented a way to collect <0 and >10 second exposures. The former returns empty images, the latter sums shorter frames collected via a re-implemented `get_movie`. I also synchronized `CameraServal.get_image` and `get_movie` and removed an issue with GUI freezing at exit. For more details, see [this](https://github.com/instamatic-dev/instamatic/pull/111#issuecomment-2690522013) comment.

AD 3, In #108, I addressed 0-second preview crashing the GUI. Since then I learned that even if exposure > 0, the GUI itself sometimes requests 0-second images. This happens because `VideoSteram.get_image` starts by setting `self.grabber.frametime = 0` to "prevent it lagging data acquisition" and does some stuff, but before `self.grabber.acquireInitiateEvent.set()`, the `ImageGraber.run` in 2nd thread races to `self.cam.get_image` and often manages to call it – with `frametime=0`. I found that replacing `self.grabber.frametime` set/restore with `self.block()`/`unblock()` achieves the same effect while never requesting a dreaded 0-second image.

AD 4, As for why the default config fails, the "cooldown" between exposures is hard-coded to 0.5ms. In fact, it should be higher if using Timepix3 asic or `"PixelDepth": 24`. On his [fork](https://github.com/hzanoli/instamatic/tree/feature/timepix3_support), @hzanoli suggests using different hard-coded values based on a new config parameter `asic` but I believe a more elegant solution is to derive it from the difference between initial `ExposureTime` and `TriggerPeriod`.

Furthermore. I noticed that for `"PixelDepth": 24`, the preview was much smoother than for `"PixelDepth": 12`. After some tests I realized that in 12-bit mode, data was passed as `pgm` and in 24-bit – as `tiff` (also enforced for Timepix3 asic by @hzanoli). I tested `pgm` and `tiff` and found out that reading `tiff` with Pillow was significantly faster. So here I ask: why even use `pgm` in the first place ([benchmark code](https://chatgpt.com/canvas/shared/67b4942e54808191bf08685ce305112d))?
```
file_format                pgm             png            tiff
bit_depth                                                    
1             117.41 ± 6.32 ms   nan ±  nan ms  0.17 ± 0.03 ms
4            117.24 ± 11.10 ms   nan ±  nan ms  0.17 ± 0.04 ms
6            151.23 ± 48.35 ms   nan ±  nan ms  0.16 ± 0.01 ms
8              0.08 ±  0.22 ms  1.41 ± 0.09 ms  0.20 ± 0.07 ms
10           153.95 ± 13.69 ms   nan ±  nan ms  0.63 ± 0.10 ms
12           153.15 ± 23.07 ms   nan ±  nan ms  0.46 ± 0.17 ms
14           150.50 ± 17.25 ms   nan ±  nan ms  0.68 ± 0.11 ms
16             1.84 ±  0.20 ms  2.10 ± 0.15 ms  0.42 ± 0.15 ms
20              nan ±   nan ms   nan ±  nan ms  2.17 ± 0.22 ms
24              nan ±   nan ms   nan ±  nan ms  2.21 ± 0.21 ms
32              nan ±   nan ms   nan ±  nan ms  2.22 ± 0.19 ms
```

When debugging, I was trying to use instamatic log but it was extremely inconvenient because currently it captures every debug message from every package. Unrelevant debug messages, mostly from PIL, are generated in an absurd rate: ~2000 if running instamatic for 12 seconds, ~100 MB / hour. So here I suggest modifying GUI file handler so that:

- Instamatic `logger.debug` messages are logged only if at least `-v` is set;
- Imported library debug statements are logged only if at least `-vv` is set;
- Log messages include whole file path instead of just module name if `-vvv` is set.

Finally, during my tests I noticed that some of the links were outdated or wrong. I was also disappointed I could not copy-and-paste Instamatic citation. So I changed that: looks slightly different but CTRL+C works!

![image](https://github.com/user-attachments/assets/8e6df1ac-7892-46d3-83f4-992cf1fecde6)


### Major changes

- `CameraServal`: Derive the length of cooldown period between exposures from config (trigger - exposure) rather than using a hard-coded value;
- ~~`CameraServal`: Hard-limit exposure times between 0.001 and 10 seconds;~~
- EDIT: `CameraServal`: If requested exposure equal or lower than 0, return an empty array.
- EDIT: `CameraServal`: If requested exposure >10, return sum of images from re-implemented `get_movie`.
- `instamatic/main.py` (GUI): Limit log size from ~100 MB/h to KB/h by not-logging debug messages unless a new flag `-v` (for insamatic) for `-vv` (for imported libraries) is specified.

### Minor changes

- `VideoStream.get_image`: Use `block()` instead of `frametime=0` to temporarily pause the preview.
- `CameraServal`: Send images in `tiff` rather than significantly-slower-to-decode `pgm`.
- EDIT: `CameraServal`: Re-implement `get_movie`, synchronize it with `get_image` to prevent errors.
- `serval.yaml`: Add comments, update values to work for ASI Timepix3 (credit: @hzanoli);
- `AboutFrame`: Fix links and make author & reference fields select-and-copy-able.

### Bugfixes

- `cred/experiment.py`: Allow using simulated FEI camera (credit: @hzanoli);
- `camera_serval.py`: Remove unused import statements;
- `AboutFrame`: Fix `__main__` so that it can be shown stand-alone if ever desired;
- `THANKS.md`: Fix the link so that it points to the correct contributors list;
- EDIT: `gui.py`: on `close()`, redirect `sys.stdout` and `sys.stderr` back so that it does not freeze GUI;
- EDIT: `tem_server.py`: make imports global to facilitate running via `main` / `instamatic.temserver`.

### Effect on the codebase
Using ASI detectors in instamatic should now work and shouldn't randomly crash at every chance. I analyzed the code and successfully ran some RED (!), and I think replacing `framerate=0` with `block()` should be fine, but arguably I do now know if it does not affect something I did not touch. Likewise with `pgm`: I don't understand why it was used in the first place, it is not faster. I do not believe anyone will miss debug logs from external libraries, but importantly now `-v` is needed to see instamatic debug messages as well.