### PR TITLE
Set phi angle in .pts input file as well

### DIFF
--- a/src/instamatic/processing/ImgConversion.py
+++ b/src/instamatic/processing/ImgConversion.py
@@ -674,7 +674,7 @@ class ImgConversion:
             print('', file=f)
             print(f'lambda {self.wavelength}', file=f)
             print(f'Aperpixel {self.pixelsize}', file=f)
-            print('phi 0.0', file=f)
+            print(f'phi {float(self.osc_angle)/2}', file=f)
             print(f'omega {omega}', file=f)
             print('bin 1', file=f)
             print('reflectionsize 20', file=f)


### PR DESCRIPTION
The rotation semi angle should be automatically set.

This is simply the oscillation angle divided by two. This is done in the same manner as it is [already done](https://github.com/instamatic-dev/instamatic/blob/ebd6d123217c195ab676535f5657f18fe423ee16/src/instamatic/processing/ImgConversion.py#L720) for the .pts2 file option.