### PR TITLE
Beam blanked unblanked

### DIFF
--- a/docs/tem_api.md
+++ b/docs/tem_api.md
@@ -183,6 +183,16 @@ To unblank the beam:
 ```python
 ctrl.beam.unblank()
 ```
+To blank the beam temporarily:
+```python
+with ctrl.beam.blanked():
+    ...
+```
+To unblank the beam temporarily:
+```python
+with ctrl.beam.unblanked():
+    ...
+```
 To get the state of the beam blanker:
 ```python
 status = ctrl.beam.status          # str

--- a/src/instamatic/experiments/cred_gatan/experiment.py
+++ b/src/instamatic/experiments/cred_gatan/experiment.py
@@ -183,15 +183,13 @@ class Experiment(ExperimentBase):
             # Center crystal position
             if self.mode == 'diff':
                 self.ctrl.difffocus.defocus(self.defocus_offset)
-            self.ctrl.beam.unblank()
-
-            input('Move SAED aperture to crystal and press <ENTER> to measure! ')
+            with self.ctrl.beam.unblanked():
+                input('Move SAED aperture to crystal and press <ENTER> to measure! ')
 
             # cannot do this while lieview is running
             # img1 = self.ctrl.get_raw_image()
             # write_tiff(self.path / "image_before.tiff", img1)
 
-            self.ctrl.beam.blank()
             if self.mode == 'diff':
                 self.ctrl.difffocus.refocus()
             time.sleep(3)
@@ -305,12 +303,9 @@ class Experiment(ExperimentBase):
             # Center crystal position
             if self.mode == 'diff':
                 self.ctrl.difffocus.defocus(self.defocus_offset)
-            self.ctrl.beam.unblank()
-
-            img2 = self.ctrl.get_rotated_image()
-            write_tiff(self.path / 'image_after.tiff', img2)
-
-            self.ctrl.beam.blank()
+            with self.ctrl.beam.unblanked():
+                img2 = self.ctrl.get_rotated_image()
+                write_tiff(self.path / 'image_after.tiff', img2)
             if self.mode == 'diff':
                 self.ctrl.difffocus.refocus()
 

--- a/src/instamatic/experiments/cred_tvips/experiment.py
+++ b/src/instamatic/experiments/cred_tvips/experiment.py
@@ -472,12 +472,9 @@ class Experiment(ExperimentBase):
             # Center crystal position
             if self.mode == 'diff':
                 self.ctrl.difffocus.defocus(self.defocus_offset)
-            self.ctrl.beam.unblank()
-
-            img2 = self.ctrl.get_rotated_image()
-            write_tiff(self.path / 'image_after.tiff', img2)
-
-            self.ctrl.beam.blank()
+            with self.ctrl.beam.unblanked():
+                img2 = self.ctrl.get_rotated_image()
+                write_tiff(self.path / 'image_after.tiff', img2)
             if self.mode == 'diff':
                 self.ctrl.difffocus.refocus()
 

--- a/src/instamatic/microscope/components/states.py
+++ b/src/instamatic/microscope/components/states.py
@@ -65,7 +65,7 @@ class Beam(State):
             time.sleep(delay)
 
     @contextmanager
-    def blanked(self, condition: Any, delay: float = 0.0) -> ContextManager[None]:
+    def blanked(self, condition=True, delay: float = 0.0) -> ContextManager[None]:
         """Temporarily blank the beam using a `with blanked` statement."""
         was_blanked_before = self.is_blanked
         try:
@@ -77,7 +77,7 @@ class Beam(State):
                 self.unblank(delay=delay)
 
     @contextmanager
-    def unblanked(self, condition: Any, delay: float = 0.0) -> ContextManager[None]:
+    def unblanked(self, condition=True, delay: float = 0.0) -> ContextManager[None]:
         """Temporarily unblank the beam using a `with unblanked` statement."""
         was_blanked_before = self.is_blanked
         try:

--- a/src/instamatic/microscope/components/states.py
+++ b/src/instamatic/microscope/components/states.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import time
+from contextlib import contextmanager
+from typing import Any, ContextManager
 
 from instamatic.microscope.base import MicroscopeBase
 
@@ -61,6 +63,30 @@ class Beam(State):
         self._setter(False)
         if delay:
             time.sleep(delay)
+
+    @contextmanager
+    def blanked(self, condition: Any, delay: float = 0.0) -> ContextManager[None]:
+        """Temporarily blank the beam using a `with blanked` statement."""
+        was_blanked_before = self.is_blanked
+        try:
+            if condition and not was_blanked_before:
+                self.blank(delay=delay)
+            yield
+        finally:
+            if condition and not was_blanked_before:
+                self.unblank(delay=delay)
+
+    @contextmanager
+    def unblanked(self, condition: Any, delay: float = 0.0) -> ContextManager[None]:
+        """Temporarily unblank the beam using a `with unblanked` statement."""
+        was_blanked_before = self.is_blanked
+        try:
+            if condition and was_blanked_before:
+                self.unblank(delay=delay)
+            yield
+        finally:
+            if condition and was_blanked_before:
+                self.blank(delay=delay)
 
     def set(self, state: str, delay: float = 0.0):
         """Set state of the beam, with optional delay in ms."""

--- a/tests/test_ctrl.py
+++ b/tests/test_ctrl.py
@@ -183,6 +183,12 @@ def test_beam(ctrl):
     beam.blank()
     assert beam.is_blanked
 
+    with beam.blanked():
+        assert beam.is_blanked
+
+    with beam.unblanked():
+        assert not beam.is_blanked
+
     beam.set(unblanked)
     assert beam.state == unblanked
 


### PR DESCRIPTION
### Context
There is a common programming pattern in instamatic to unblank and then blank (or *vice versa*) the beam in short succession. The `get_image` method built into controller as well as many experimental procedures often do that either to briefly shield the detector or to collect a single image without exposing the sample too much. Unfortunately, this is typically done by 1) checking if beam is blanked, 2) checking if auto-blank is on, 3) blanking the beam, 4) reverting the blanking if needed after the fact. This pattern is not very large, but it repeats over the whole code base 22 times, according to my counting.

This small PR suggest adding two new context manager methods to the `Beam` object: `blanked` and `unblanked`. These can be used via the `with` keyword and they significantly shorten the boilerplate code used to check for previous blanking, auto-blanking, delay etc., placing them all into a one call and determining the scope via indentation. For example, in the controller the `get_image` function gets simplified from this (empty lines ommited):
```python
if self.autoblank:
    self.beam.unblank()
h['ImageGetTimeStart'] = time.perf_counter()
arr = self.get_rotated_image(exposure=exposure, binsize=binsize)
h['ImageGetTimeEnd'] = time.perf_counter()
if self.autoblank:
    self.beam.blank()
```
To this:
```python
with self.beam.unblanked(condition=self.autoblank):
    h['ImageGetTimeStart'] = time.perf_counter()
    arr = self.get_rotated_image(exposure=exposure, binsize=binsize)
    h['ImageGetTimeEnd'] = time.perf_counter()
```

Apart from adding the new method, I have applied them in 10 selected places where it was straightforward and where I knew it does not change the behavior. As a consequence you can see that this PR adds only a few more line than it removes, even though it expands the documentation and the existing test.

### Code changes
- Introduced two new `beam.blanked` and `beam.unblanked` context manager methods that can simplify code with sequential calls to `beam.blank` and `beam.unblank`.