### PR TITLE
Fix carriage return to correctly remove lines from the GUI console

### DIFF
--- a/src/instamatic/gui/console_frame.py
+++ b/src/instamatic/gui/console_frame.py
@@ -22,6 +22,8 @@ class Writer:
         Tkinter text / scrolledtext widget to redirect stdout to
     """
 
+    ANSI_ESCAPE = re.compile(r'\x1b\[[0-9;]*[a-zA-Z]')
+
     def __init__(self, text, add_timestamp=False):
         self.terminal = sys.__stdout__
         self.text = text
@@ -36,9 +38,11 @@ class Writer:
     def write(self, message: str) -> None:
         self.terminal.write(message)
 
-        if '\r\x1b[K' in message:  # tkinter.Text can't handle carriage returns
-            message = message.rsplit('\r\x1b[K', maxsplit=1)[-1]
-        self.text.delete('insert linestart', 'insert lineend')
+        if '\r' in message:  # tkinter.Text can't handle carriage returns
+            message = message.rsplit('\r', maxsplit=1)[-1]
+            self.text.delete('insert linestart', 'insert lineend')
+
+        message = self.ANSI_ESCAPE.sub('', message)
 
         if self._add_timestamp and message != '\n':
             message = f'[{time.strftime("%H:%M:%S")}] {message}'

--- a/src/instamatic/gui/console_frame.py
+++ b/src/instamatic/gui/console_frame.py
@@ -28,12 +28,6 @@ class Writer:
         self.terminal = sys.__stdout__
         self.text = text
         self._add_timestamp = add_timestamp
-        self.timestamps = {}
-        import atexit
-
-        atexit.register(
-            lambda: print('\n'.join(f'{k}: {v}' for k, v in self.timestamps.items()))
-        )
 
     def write(self, message: str) -> None:
         self.terminal.write(message)
@@ -42,13 +36,12 @@ class Writer:
             message = message.rsplit('\r', maxsplit=1)[-1]
             self.text.delete('insert linestart', 'insert lineend')
 
-        message = self.ANSI_ESCAPE.sub('', message)
+        message = self.ANSI_ESCAPE.sub('', message)  # remove ANSI escape codes
 
         if self._add_timestamp and message != '\n':
             message = f'[{time.strftime("%H:%M:%S")}] {message}'
 
         self.text.insert(END, message)
-        self.timestamps[message] = time.perf_counter_ns()
         self.text.see(END)
 
     def flush(self, *args, **kwargs):


### PR DESCRIPTION
### Context
If you work with Instamatic and tqdm, or you tried to run some calibration from the main GUI which communicates using the `instamatic.tools.printer` with '\r\x1b[K' return sequence, you probably ran into the same problem I have. While both these commands produce quickly-changing strings in the command-line terminal, e.g. progress bars, the carriage return does not work correctly in the GUI console. According to my research, it should not: `tkinter.Text` was never designed with carriage return or ANSI escape codes in mind. As a result, after counting merely to 25, it starts looking like that:

![image](https://github.com/user-attachments/assets/a641be49-d98e-432e-ae92-8eace135a9ef)

This PR improves the behavior of the carriage return symbol '\r': any time console's `Writer` class now gets a message with '\r', it will immediately strip everything on its left, remove the carriage return, remove any other ANSI escape codes, delete the last message in the terminal, and print the new message in its place. As a result, both `tqdm` and `printer` now work completely correctly in the GUI! You can even update a line yourself by passing a string that starts with '\r'. Below you will see the beam shift calibration running completely correctly in the GUI console:

![image](https://github.com/user-attachments/assets/56d693d1-d5ab-4583-8908-fb9fe3b87ee1)

This has an added benefit (i.e. my original reason to look at it): it makes the GUI faster! For very long lines, tkinter can take surprisingly long to calculate line wrapping. As an example, I ran a 15 x 15 = 225-point beam shift calibration on 2 PCs, my work PC1 and the microscope-handling PC2. After ~200 points, writing to the console on PC2 took longer than the rest of the calibration step!

![image](https://github.com/user-attachments/assets/f496af16-ff3b-4947-964f-beb767a8db8c)

The only caveat with this PR is it makes the GUI actively remove lines from the console. This means that if the user clicks somewhere in the console during `tqdm` or `printer` loop, the console might start removing random lines and appending new info at the end. Previously it would only write in a completely wrong place. Given that the console itself is very wonky and user can just as well remove data by hand (because it is a normal text field), I am not particularly concerned with it.

Note: you can test the feature using Advanced tab -> run custom script -> 'showcase_movie.py', left in `src/instamatic/config/scripts/showcase_movie.py` after PR #121. I can see not time improvements there, but the caret return works as intended.

### Bug fixes

- Carriage return '\r' is now correctly handled by the Instamatic GUI, making `tqdm` and `printer` output much nicer;
- ANSI escape sentences are not handled by console and thus removed instead of being printed as text.
