### PR TITLE
Remove conversion to uint16

### DIFF
--- a/src/instamatic/processing/ImgConversion.py
+++ b/src/instamatic/processing/ImgConversion.py
@@ -449,9 +449,6 @@ class ImgConversion:
         img = self.data[i]
         h = self.headers[i]
 
-        # PETS reads only 16bit unsignt integer TIFF
-        img = np.round(img, 0).astype(np.uint16)
-
         fn = path / f'{i:05d}.tiff'
         write_tiff(fn, img, header=h)
         return fn


### PR DESCRIPTION
Fixes #120. This is how we did it on our microscope. Afaik the input is always uint, so np.round(img, 0) is a noop. If this is not the case, the rounding should be added back in.