### PR TITLE
Systematize `setStagePosition` signature, make `None` speed sentinel

### DIFF
--- a/src/instamatic/microscope/base.py
+++ b/src/instamatic/microscope/base.py
@@ -188,6 +188,8 @@ class MicroscopeBase(ABC):
         z: Optional[int_nm],
         a: Optional[float_deg],
         b: Optional[float_deg],
+        *,
+        speed: Optional[float],
         wait: bool,
     ) -> None:
         pass

--- a/src/instamatic/microscope/interface/fei_microscope.py
+++ b/src/instamatic/microscope/interface/fei_microscope.py
@@ -165,13 +165,16 @@ class FEIMicroscope(MicroscopeBase):
         z: Optional[int_nm] = None,
         a: Optional[float_deg] = None,
         b: Optional[float_deg] = None,
+        *,
+        speed: Optional[float] = None,
         wait: bool = True,
-        speed: float = 1.0,
     ) -> None:
         """X, y, z in the system are in unit of meters, angles in radians."""
         pos = self.stage.Position
         axis = 0
 
+        if speed is None:
+            speed = 1.0
         if speed > 1 or speed < 0:
             raise FEIValueError(f'setStageSpeed value must be between 0 and 1. Input: {speed}')
 

--- a/src/instamatic/microscope/interface/fei_simu_microscope.py
+++ b/src/instamatic/microscope/interface/fei_simu_microscope.py
@@ -252,8 +252,9 @@ class FEISimuMicroscope(MicroscopeBase):
         z: Optional[int_nm] = None,
         a: Optional[float_deg] = None,
         b: Optional[float_deg] = None,
+        *,
+        speed: Optional[float] = None,
         wait: bool = True,
-        speed: float = 1.0,
     ) -> None:
         if z is not None:
             self.setStageZ(z)
@@ -273,6 +274,8 @@ class FEISimuMicroscope(MicroscopeBase):
         z: Optional[int_nm] = None,
         a: Optional[float_deg] = None,
         b: Optional[float_deg] = None,
+        *,
+        speed: Optional[float] = None,
         wait: bool = False,
     ) -> None:
         if z is not None:

--- a/src/instamatic/microscope/interface/jeol_microscope.py
+++ b/src/instamatic/microscope/interface/jeol_microscope.py
@@ -342,7 +342,6 @@ class JeolMicroscope(MicroscopeBase):
         a: Optional[float_deg] = None,
         b: Optional[float_deg] = None,
         *,
-        speed: Optional[float] = None,
         wait: bool = True,
     ) -> None:
         if z is not None:

--- a/src/instamatic/microscope/interface/jeol_microscope.py
+++ b/src/instamatic/microscope/interface/jeol_microscope.py
@@ -341,6 +341,8 @@ class JeolMicroscope(MicroscopeBase):
         z: Optional[int_nm] = None,
         a: Optional[float_deg] = None,
         b: Optional[float_deg] = None,
+        *,
+        speed: Optional[float] = None,
         wait: bool = True,
     ) -> None:
         if z is not None:

--- a/src/instamatic/microscope/interface/simu_microscope.py
+++ b/src/instamatic/microscope/interface/simu_microscope.py
@@ -433,7 +433,8 @@ class SimuMicroscope(MicroscopeBase):
         z: Optional[int_nm] = None,
         a: Optional[float_deg] = None,
         b: Optional[float_deg] = None,
-        speed: float = -1,
+        *,
+        speed: Optional[float] = None,
         wait: bool = True,
     ) -> None:
         if z is not None:

--- a/src/instamatic/microscope/interface/simu_microscope.py
+++ b/src/instamatic/microscope/interface/simu_microscope.py
@@ -435,6 +435,7 @@ class SimuMicroscope(MicroscopeBase):
         b: Optional[float_deg] = None,
         *,
         wait: bool = True,
+        speed: Optional[float] = None,
     ) -> None:
         if z is not None:
             self.setStageZ(z, wait=wait)

--- a/src/instamatic/microscope/interface/simu_microscope.py
+++ b/src/instamatic/microscope/interface/simu_microscope.py
@@ -434,7 +434,6 @@ class SimuMicroscope(MicroscopeBase):
         a: Optional[float_deg] = None,
         b: Optional[float_deg] = None,
         *,
-        speed: Optional[float] = None,
         wait: bool = True,
     ) -> None:
         if z is not None:


### PR DESCRIPTION
This is only a small suggestion, an crystallization of an idea that came to my mind when working on instamatic-dev/instamatic-tecnai-server#3. I noticed that the signature of `setStagePosition` varies wildly between different implementations. Not only the keyword parametrs differ, but also their default values, which is against our own base class.

I understand that in some implementations `wait` or `speed` are not used, but I doubt having various method signatures is the best way to address that, especially since some implementations already do use full the signature and then simply do not refer to unused parameters. I think this is more cleaner way, especially with the added suggestion that `speed` and `wait` should be always keyword parameters only (`*,`). In fact, i think specifying the keyword-only parameters using `*,` is more important here than unifying the signature itself since without it `set(0,0,0,0,0,1)` can be interpreted both as `wait=1` and `speed=1`.

Long term it would be better IMO to have a more complex system or flags that checks whether microscope supports `wait` or `speed`.