### PR TITLE
Fix TEMController alignments being incorrectly stored and restored

### DIFF
--- a/src/instamatic/config/__init__.py
+++ b/src/instamatic/config/__init__.py
@@ -90,13 +90,9 @@ def get_base_drc():
 
 def get_alignments() -> dict:
     """Get alignments from the alignment directory and return them as a dict of
-    dicts.
-
-    Use `ctrl.from_dict` to load the alignments
-    """
-    fns = alignments_drc.glob('*.yaml')
-    alignments = {fn.name: yaml.full_load(open(fn)) for fn in fns}
-    return alignments
+    dicts; Use `ctrl.from_dict` to load previously-stored alignments."""
+    yaml_filenames = alignments_drc.glob('*.yaml')
+    return {fn.stem: yaml.safe_load(open(fn)) for fn in yaml_filenames}
 
 
 class ConfigObject:


### PR DESCRIPTION
### Context
I tried using the functionality of `TEMController.store` and `TEMController.restore` and have it utterly fail. I discovered two issues; firstly, `store` was serializing custom python objects e.g. the `DeflectorTuple`, which `restore` could not deserialize because it was never informed *how*. Secondly, `restore` was restoring the config under wrong names, e.g. built-in `neutral.yaml` (which to the best of my knowledge is completely unused, by the way) was being restored under the name `neutral.yaml` instead of `neutral`. Consequently, if you tried storing and restoring some config, you would not only fail because of wrong types, but the restored object would also have a different name.

Before:
```yaml
BeamShift: !!python/object/new:instamatic.microscope.components.deflectors.DeflectorTuple
- 16474
- 62896
BeamTilt: !!python/object/new:instamatic.microscope.components.deflectors.DeflectorTuple
- 50357
- 8232
Brightness: 51716
```

After:
```yaml
BeamShift:
- 16474
- 62896
BeamTilt:
- 50357
- 8232
Brightness: 51716
```

The patch I suggested here is ugly but it works, and I (absolutely want to, but) shouldn't waste too much time on rewriting the entire alignment handling right now. I also swapped yaml reader from general to save, because the former is less safe and we don't need it.

### Bugfixes
- Fix the issue with `TEMController.store` producing unreadable alignment files;
- Fix the issue with `TEMController.restore` saving restored alignments under wrong names.