### PR TITLE
Tighten code and add magnification control to the hand panel

### DIFF
--- a/src/instamatic/gui/ctrl_frame.py
+++ b/src/instamatic/gui/ctrl_frame.py
@@ -49,11 +49,11 @@ class ExperimentalCtrl(LabelFrame):
         Label(frame, text='Angle (0)', width=20).grid(row=2, column=0, sticky='W')
         Label(frame, text='Angle (+)', width=20).grid(row=3, column=0, sticky='W')
         Label(frame, text='Alpha wobbler (±)', width=20).grid(row=4, column=0, sticky='W')
-        Label(frame, text='Stage(XY)', width=20).grid(row=6, column=0, sticky='W')
+        Label(frame, text='Stage (XY)', width=20).grid(row=6, column=0, sticky='W')
 
         angle = {'width': 10, 'from_': -90, 'to': 90, 'increment': 5}
         angle_i1 = {**angle, 'increment': 1}
-        stage = {'width': 10, 'from_': -1e6, 'to': 1e6, 'increment': 1000}
+        stage = {'width': 10, 'from_': -1e6, 'to': 1e6, 'increment': 100}
 
         e_negative_angle = Spinbox(frame, textvariable=self.var_negative_angle, **angle)
         e_negative_angle.grid(row=1, column=1, sticky='EW')
@@ -102,7 +102,7 @@ class ExperimentalCtrl(LabelFrame):
         b_stage_get.grid(row=6, column=4, sticky='W')
 
         # defocus button
-        Label(frame, text='Diff defocus:', width=20).grid(row=13, column=0, sticky='W')
+        Label(frame, text='Diff defocus', width=20).grid(row=13, column=0, sticky='W')
         self.e_diff_defocus = Spinbox(
             frame,
             textvariable=self.var_diff_defocus,

--- a/src/instamatic/gui/ctrl_frame.py
+++ b/src/instamatic/gui/ctrl_frame.py
@@ -48,7 +48,7 @@ class ExperimentalCtrl(LabelFrame):
         Label(frame, text='Angle (0)', width=20).grid(row=2, column=0, sticky='W')
         Label(frame, text='Angle (+)', width=20).grid(row=3, column=0, sticky='W')
         Label(frame, text='Alpha wobbler (±)', width=20).grid(row=4, column=0, sticky='W')
-        Label(frame, text='Stage (XY)', width=20).grid(row=6, column=0, sticky='W')
+        Label(frame, text='Stage (XYZ)', width=20).grid(row=6, column=0, sticky='W')
 
         angle = {'width': 10, 'from_': -90, 'to': 90, 'increment': 5}
         angle_i1 = {**angle, 'increment': 1}
@@ -75,6 +75,8 @@ class ExperimentalCtrl(LabelFrame):
         e_stage_x.grid(row=6, column=1, sticky='EW')
         e_stage_y = Spinbox(frame, textvariable=self.var_stage_y, **stage)
         e_stage_y.grid(row=6, column=2, sticky='EW')
+        e_stage_z = Spinbox(frame, textvariable=self.var_stage_z, **stage)
+        e_stage_z.grid(row=6, column=3, sticky='EW')
 
         if config.settings.use_goniotool:
             Label(frame, text='Rot. Speed', width=20).grid(row=5, column=0, sticky='W')
@@ -97,9 +99,9 @@ class ExperimentalCtrl(LabelFrame):
         b_positive_angle.grid(row=3, column=2, sticky='W')
 
         b_stage = Button(frame, text='Set', command=self.set_stage)
-        b_stage.grid(row=6, column=3, sticky='W')
+        b_stage.grid(row=6, column=4, sticky='W')
         b_stage_get = Button(frame, text='Get', command=self.get_stage)
-        b_stage_get.grid(row=6, column=4, sticky='W')
+        b_stage_get.grid(row=6, column=5, sticky='W')
 
         # defocus button
         Label(frame, text='Diff defocus', width=20).grid(row=13, column=0, sticky='W')
@@ -196,6 +198,7 @@ class ExperimentalCtrl(LabelFrame):
 
         self.var_stage_x = IntVar(value=0)
         self.var_stage_y = IntVar(value=0)
+        self.var_stage_z = IntVar(value=0)
 
         self.var_goniotool_tx = IntVar(value=1)
 
@@ -272,6 +275,7 @@ class ExperimentalCtrl(LabelFrame):
                     'task': 'stage.set',
                     'x': self.var_stage_x.get(),
                     'y': self.var_stage_y.get(),
+                    'z': self.var_stage_z.get(),
                     'wait': self.var_stage_wait.get(),
                 },
             )
@@ -279,9 +283,10 @@ class ExperimentalCtrl(LabelFrame):
         self.triggerEvent.set()
 
     def get_stage(self, event=None):
-        x, y, _, _, _ = self.ctrl.stage.get()
+        x, y, z, _, _ = self.ctrl.stage.get()
         self.var_stage_x.set(round(x))
         self.var_stage_y.set(round(y))
+        self.var_stage_z.set(round(z))
 
     def toggle_alpha_wobbler(self):
         if self.var_alpha_wobbler_on.get():

--- a/src/instamatic/gui/ctrl_frame.py
+++ b/src/instamatic/gui/ctrl_frame.py
@@ -238,44 +238,19 @@ class ExperimentalCtrl(LabelFrame):
     def get_difffocus(self, event=None):
         self.var_difffocus.set(self.ctrl.difffocus.get())
 
-    def set_negative_angle(self):
-        self.q.put(
-            (
-                'ctrl',
-                {
-                    'task': 'stage.set',
-                    'a': self.var_negative_angle.get(),
-                    'wait': self.var_stage_wait.get(),
-                },
-            )
-        )
+    def _set_angle(self, var: Variable) -> None:
+        kwargs = {'task': 'stage.set', 'a': var.get(), 'wait': self.var_stage_wait.get()}
+        self.q.put(('ctrl', kwargs))
         self.triggerEvent.set()
+
+    def set_negative_angle(self):
+        return self._set_angle(self.var_negative_angle)
 
     def set_neutral_angle(self):
-        self.q.put(
-            (
-                'ctrl',
-                {
-                    'task': 'stage.set',
-                    'a': self.var_neutral_angle.get(),
-                    'wait': self.var_stage_wait.get(),
-                },
-            )
-        )
-        self.triggerEvent.set()
+        return self._set_angle(self.var_neutral_angle)
 
     def set_positive_angle(self):
-        self.q.put(
-            (
-                'ctrl',
-                {
-                    'task': 'stage.set',
-                    'a': self.var_positive_angle.get(),
-                    'wait': self.var_stage_wait.get(),
-                },
-            )
-        )
-        self.triggerEvent.set()
+        return self._set_angle(self.var_positive_angle)
 
     def set_goniotool_tx(self, event=None, value=None):
         if not value:

--- a/src/instamatic/gui/ctrl_frame.py
+++ b/src/instamatic/gui/ctrl_frame.py
@@ -22,6 +22,9 @@ class ExperimentalCtrl(LabelFrame):
 
         frame = Frame(self)
 
+        stage_reset_btn = Button(frame, text='Reset stage', command=self.reset_stage)
+        stage_reset_btn.grid(row=0, column=1, sticky='W')
+
         b_stage_stop = Button(frame, text='Stop stage', command=self.stage_stop)
         b_stage_stop.grid(row=0, column=2, sticky='W')
 
@@ -31,51 +34,36 @@ class ExperimentalCtrl(LabelFrame):
         b_find_eucentric_height = Button(
             frame, text='Find eucentric height', command=self.find_eucentric_height
         )
-        b_find_eucentric_height.grid(row=0, column=0, sticky='EW', columnspan=2)
+        b_find_eucentric_height.grid(row=0, column=0, sticky='EW')
 
         Label(frame, text='Mode:').grid(row=8, column=0, sticky='W')
-        self.o_mode = OptionMenu(
-            frame,
-            self.var_mode,
-            'diff',
-            'diff',
-            'mag1',
-            'mag2',
-            'lowmag',
-            'samag',
-            command=self.set_mode,
-        )
-        self.o_mode.grid(row=8, column=1, sticky='W', padx=10)
+        ranges = config.microscope.ranges
+        modes = list(ranges.keys())
+        self.o_mode = OptionMenu(frame, self.var_mode, modes[0], *modes, command=self.set_mode)
+        self.o_mode.grid(row=8, column=1, sticky='EW')
 
         frame.pack(side='top', fill='x', padx=10, pady=10)
 
         frame = Frame(self)
-        stage_reset_btn = Button(frame, text='Reset stage', command=self.reset_stage)
-        stage_reset_btn.grid(row=0, column=0, sticky='W')
-
         Label(frame, text='Angle (-)', width=20).grid(row=1, column=0, sticky='W')
         Label(frame, text='Angle (0)', width=20).grid(row=2, column=0, sticky='W')
         Label(frame, text='Angle (+)', width=20).grid(row=3, column=0, sticky='W')
         Label(frame, text='Alpha wobbler (±)', width=20).grid(row=4, column=0, sticky='W')
         Label(frame, text='Stage(XY)', width=20).grid(row=6, column=0, sticky='W')
 
-        e_negative_angle = Spinbox(
-            frame, width=10, textvariable=self.var_negative_angle, from_=-90, to=90, increment=5
-        )
-        e_negative_angle.grid(row=1, column=1, sticky='EW')
-        e_neutral_angle = Spinbox(
-            frame, width=10, textvariable=self.var_neutral_angle, from_=-90, to=90, increment=5
-        )
-        e_neutral_angle.grid(row=2, column=1, sticky='EW')
-        e_positive_angle = Spinbox(
-            frame, width=10, textvariable=self.var_positive_angle, from_=-90, to=90, increment=5
-        )
-        e_positive_angle.grid(row=3, column=1, sticky='EW')
+        angle = {'width': 10, 'from_': -90, 'to': 90, 'increment': 5}
+        angle_i1 = {**angle, 'increment': 1}
+        stage = {'width': 10, 'from_': -1e6, 'to': 1e6, 'increment': 1000}
 
-        e_alpha_wobbler = Spinbox(
-            frame, width=10, textvariable=self.var_alpha_wobbler, from_=-90, to=90, increment=1
-        )
+        e_negative_angle = Spinbox(frame, textvariable=self.var_negative_angle, **angle)
+        e_negative_angle.grid(row=1, column=1, sticky='EW')
+        e_neutral_angle = Spinbox(frame, textvariable=self.var_neutral_angle, **angle)
+        e_neutral_angle.grid(row=2, column=1, sticky='EW')
+        e_positive_angle = Spinbox(frame, textvariable=self.var_positive_angle, **angle)
+        e_positive_angle.grid(row=3, column=1, sticky='EW')
+        e_alpha_wobbler = Spinbox(frame, textvariable=self.var_alpha_wobbler, **angle_i1)
         e_alpha_wobbler.grid(row=4, column=1, sticky='EW')
+
         self.b_start_wobble = Button(frame, text='Start', command=self.start_alpha_wobbler)
         self.b_start_wobble.grid(row=4, column=2, sticky='W')
         self.b_stop_wobble = Button(
@@ -83,9 +71,9 @@ class ExperimentalCtrl(LabelFrame):
         )
         self.b_stop_wobble.grid(row=4, column=3, sticky='W')
 
-        e_stage_x = Entry(frame, width=10, textvariable=self.var_stage_x)
+        e_stage_x = Spinbox(frame, textvariable=self.var_stage_x, **stage)
         e_stage_x.grid(row=6, column=1, sticky='EW')
-        e_stage_y = Entry(frame, width=10, textvariable=self.var_stage_y)
+        e_stage_y = Spinbox(frame, textvariable=self.var_stage_y, **stage)
         e_stage_y.grid(row=6, column=2, sticky='EW')
 
         if config.settings.use_goniotool:
@@ -170,19 +158,15 @@ class ExperimentalCtrl(LabelFrame):
         mag_dec_btn = Button(frame, text='-', command=self.decrease_mag)
         mag_dec_btn.grid(row=14, column=2)
 
-        frame.pack(side='top', fill='x', padx=10, pady=10)
-
-        frame = Frame(self)
-
-        Label(frame, text='DiffFocus', width=20).grid(row=11, column=0, sticky='W')
+        Label(frame, text='DiffFocus', width=20).grid(row=21, column=0, sticky='W')
         e_difffocus = Entry(frame, width=10, textvariable=self.var_difffocus)
-        e_difffocus.grid(row=11, column=1, sticky='W')
+        e_difffocus.grid(row=21, column=1, sticky='W')
 
         b_difffocus = Button(frame, text='Set', command=self.set_difffocus)
-        b_difffocus.grid(row=11, column=2, sticky='W')
+        b_difffocus.grid(row=21, column=2, sticky='WE')
 
         b_difffocus_get = Button(frame, text='Get', command=self.get_difffocus)
-        b_difffocus_get.grid(row=11, column=3, sticky='W')
+        b_difffocus_get.grid(row=21, column=3, sticky='W')
 
         slider = Scale(
             frame,
@@ -192,7 +176,7 @@ class ExperimentalCtrl(LabelFrame):
             orient=HORIZONTAL,
             command=self.set_difffocus,
         )
-        slider.grid(row=12, column=0, columnspan=3, sticky='EW')
+        slider.grid(row=22, column=0, columnspan=3, sticky='EW')
 
         frame.pack(side='top', fill='x', padx=10, pady=10)
 

--- a/src/instamatic/gui/ctrl_frame.py
+++ b/src/instamatic/gui/ctrl_frame.py
@@ -50,6 +50,8 @@ class ExperimentalCtrl(LabelFrame):
         frame.pack(side='top', fill='x', padx=10, pady=10)
 
         frame = Frame(self)
+        stage_reset_btn = Button(frame, text='Reset stage', command=self.reset_stage)
+        stage_reset_btn.grid(row=0, column=0, sticky='W')
 
         Label(frame, text='Angle (-)', width=20).grid(row=1, column=0, sticky='W')
         Label(frame, text='Angle (0)', width=20).grid(row=2, column=0, sticky='W')
@@ -161,6 +163,13 @@ class ExperimentalCtrl(LabelFrame):
         )
         slider.grid(row=12, column=0, columnspan=3, sticky='EW')
 
+        # Magnification
+        Label(frame, text='Magnification', width=20).grid(row=14, column=0, sticky='W')
+        mag_inc_btn = Button(frame, text='+', command=self.increase_mag)
+        mag_inc_btn.grid(row=14, column=1)
+        mag_dec_btn = Button(frame, text='-', command=self.decrease_mag)
+        mag_dec_btn.grid(row=14, column=2)
+
         frame.pack(side='top', fill='x', padx=10, pady=10)
 
         frame = Frame(self)
@@ -227,6 +236,15 @@ class ExperimentalCtrl(LabelFrame):
 
     def get_brightness(self, event=None):
         self.var_brightness.set(self.ctrl.brightness.get())
+
+    def increase_mag(self):
+        self.ctrl.magnification.increase()
+
+    def decrease_mag(self):
+        self.ctrl.magnification.decrease()
+
+    def reset_stage(self):
+        self.ctrl.stage.set(0, 0, 0, 0, 0)
 
     def set_difffocus(self, event=None):
         self.var_difffocus.set(self.var_difffocus.get())

--- a/src/instamatic/gui/ctrl_frame.py
+++ b/src/instamatic/gui/ctrl_frame.py
@@ -37,8 +37,7 @@ class ExperimentalCtrl(LabelFrame):
         b_find_eucentric_height.grid(row=0, column=0, sticky='EW')
 
         Label(frame, text='Mode:').grid(row=8, column=0, sticky='W')
-        ranges = config.microscope.ranges
-        modes = list(ranges.keys())
+        modes = list(config.microscope.ranges.keys())
         self.o_mode = OptionMenu(frame, self.var_mode, modes[0], *modes, command=self.set_mode)
         self.o_mode.grid(row=8, column=1, sticky='EW')
 
@@ -225,12 +224,14 @@ class ExperimentalCtrl(LabelFrame):
 
     def increase_mag(self):
         self.ctrl.magnification.increase()
+        print(f'Set magnification: {self.ctrl.magnification.get()}')
 
     def decrease_mag(self):
         self.ctrl.magnification.decrease()
+        print(f'Set magnification: {self.ctrl.magnification.get()}')
 
     def reset_stage(self):
-        self.ctrl.stage.set(0, 0, 0, 0, 0)
+        self.ctrl.stage.neutral()
 
     def set_difffocus(self, event=None):
         self.var_difffocus.set(self.var_difffocus.get())

--- a/src/instamatic/gui/ctrl_frame.py
+++ b/src/instamatic/gui/ctrl_frame.py
@@ -70,7 +70,7 @@ class ExperimentalCtrl(LabelFrame):
             variable=self.var_alpha_wobbler_on,
             command=self.toggle_alpha_wobbler,
         )
-        b_wobble.grid(row=4, column=2, sticky='W')
+        b_wobble.grid(row=4, column=2, sticky='W', columnspan=2)
 
         e_stage_x = Spinbox(frame, textvariable=self.var_stage_x, **stage)
         e_stage_x.grid(row=6, column=1, sticky='EW')

--- a/src/instamatic/microscope/components/lenses.py
+++ b/src/instamatic/microscope/components/lenses.py
@@ -135,13 +135,13 @@ class Magnification(Lens):
         try:
             self.index += 1
         except ValueError:
-            print(f'Error: Cannot change magnficication index (current={self.value}).')
+            print(f'Error: Cannot change magnification index (current={self.value}).')
 
     def decrease(self) -> None:
         try:
             self.index -= 1
         except ValueError:
-            print(f'Error: Cannot change magnficication index (current={self.value}).')
+            print(f'Error: Cannot change magnification index (current={self.value}).')
 
     def get_ranges(self) -> dict:
         """Runs through all modes and fetches all the magnification settings

--- a/src/instamatic/microscope/interface/simu_microscope.py
+++ b/src/instamatic/microscope/interface/simu_microscope.py
@@ -58,6 +58,8 @@ class SimuMicroscope(MicroscopeBase):
 
         self.BeamShift_x = random.randint(MIN, MAX)
         self.BeamShift_y = random.randint(MIN, MAX)
+        self.BeamShift_x = 0
+        self.BeamShift_y = 0
 
         self.BeamTilt_x = random.randint(MIN, MAX)
         self.BeamTilt_y = random.randint(MIN, MAX)

--- a/src/instamatic/microscope/interface/simu_microscope.py
+++ b/src/instamatic/microscope/interface/simu_microscope.py
@@ -58,8 +58,6 @@ class SimuMicroscope(MicroscopeBase):
 
         self.BeamShift_x = random.randint(MIN, MAX)
         self.BeamShift_y = random.randint(MIN, MAX)
-        self.BeamShift_x = 0
-        self.BeamShift_y = 0
 
         self.BeamTilt_x = random.randint(MIN, MAX)
         self.BeamTilt_y = random.randint(MIN, MAX)


### PR DESCRIPTION
Introduces minor changes to the manual control panel aimed to add magnification buttons suggested by @viljarjf in #140 and tighten it a bit, both in terms of code quality/quantity and space taken in the GUI:

- "Modes" drawback now pulls modes from config instead of using hard-coded ['diff', 'mag1', 'mag2', 'lowmag', 'samag'];
- "Reset stage" button that otherwise took entire line was moved to the top of the frame, next to other buttons;
- "Stage (XY)" fields were changed from `Entry` to `Spinbox` with 100-nm increment to allow setting with mouse;
- Wobbler control changed from two mutually-exclusive buttons (Start/Stop) to a checkbutton akin defocus;
- Magnification "+" and "–" buttons added (@viljarjf );
- Removed spacing between brightness and focus controls – now the "mechanical" and "beam" controls are split neatly;
- Fixed minor typos and spacing inconsistencies, generalized some methods.

| Before | After |
| --- | --- |
| <img width="654" height="559" alt="image" src="https://github.com/user-attachments/assets/30b8ca87-b2a9-4e7b-8877-a165b83681e9" /> | <img width="655" height="560" alt="image" src="https://github.com/user-attachments/assets/000d87d6-780a-4098-805d-35c79072e43f" /> |

Note how the refreshed panel has the same height as the old one despite having a new row.

When I started editing I had large changes in mind, but I decided to scale them down and leave the spotlight on the simulator for the time being. On accident, I also found out that repeatedly turning the alpha wobbler on and off consistently crashes Instamatic. Could not fix it quickly, this is a low-priority issue for the future.