### PR TITLE
Fix and allow streamable server cameras

### DIFF
--- a/src/instamatic/camera/__init__.py
+++ b/src/instamatic/camera/__init__.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-from .camera import Camera
+from .camera import get_camera, get_camera_class
 from .videostream import VideoStream

--- a/src/instamatic/camera/camera.py
+++ b/src/instamatic/camera/camera.py
@@ -56,7 +56,6 @@ def Camera(name: str = None, as_stream: bool = False, use_server: bool = False):
         from instamatic.camera.camera_client import CamClient
 
         cam = CamClient(name=name, interface=interface)
-        as_stream = False  # precaution
     else:
         cam_cls = get_cam(interface)
 

--- a/src/instamatic/camera/camera_client.py
+++ b/src/instamatic/camera/camera_client.py
@@ -111,9 +111,7 @@ class CamClient:
             dct = {'attr_name': attr_name}
             return self._eval_dct(dct)
         else:
-            raise AttributeError(
-                f'`{self.__class__.__name__}` object has no attribute `{attr_name}`'
-            )
+            wrapped = None  # AFAIK can't wrap with None, can cause odd errors
 
         @wraps(wrapped)
         def wrapper(*args, **kwargs):

--- a/src/instamatic/camera/camera_client.py
+++ b/src/instamatic/camera/camera_client.py
@@ -103,6 +103,7 @@ class CamClient:
         print(f'Connected to CAM server ({HOST}:{PORT})')
 
     def __getattr__(self, attr_name):
+        print(self._dct)
         if attr_name in self._dct:
             if attr_name in object.__getattribute__(self, '_attr_dct'):
                 return self._eval_dct({'attr_name': attr_name})

--- a/src/instamatic/camera/camera_client.py
+++ b/src/instamatic/camera/camera_client.py
@@ -103,7 +103,6 @@ class CamClient:
         print(f'Connected to CAM server ({HOST}:{PORT})')
 
     def __getattr__(self, attr_name):
-        print(self._dct)
         if attr_name in self._dct:
             if attr_name in object.__getattribute__(self, '_attr_dct'):
                 return self._eval_dct({'attr_name': attr_name})

--- a/src/instamatic/camera/camera_client.py
+++ b/src/instamatic/camera/camera_client.py
@@ -82,6 +82,7 @@ class CamClient:
         self.buffers: Dict[str, np.ndarray] = {}
         self.shms = {}
 
+        self._attr_dct: dict = {}
         self._init_dict()
         self._init_attr_dict()
 
@@ -103,6 +104,8 @@ class CamClient:
 
     def __getattr__(self, attr_name):
         if attr_name in self._dct:
+            if attr_name in object.__getattribute__(self, '_attr_dct'):
+                return self._eval_dct({'attr_name': attr_name})
             wrapped = self._dct[attr_name]
         elif attr_name in self._attr_dct:
             dct = {'attr_name': attr_name}

--- a/src/instamatic/camera/camera_client.py
+++ b/src/instamatic/camera/camera_client.py
@@ -155,9 +155,9 @@ class CamClient:
     def _init_dict(self):
         """Get list of functions and their doc strings from the uninitialized
         class."""
-        from instamatic.camera.camera import get_cam
+        from instamatic.camera.camera import get_camera_class
 
-        cam = get_cam(self.interface)
+        cam = get_camera_class(self.interface)
 
         self._dct = {
             key: value for key, value in cam.__dict__.items() if not key.startswith('_')

--- a/src/instamatic/camera/camera_client.py
+++ b/src/instamatic/camera/camera_client.py
@@ -55,7 +55,6 @@ class CamClient:
         self.name = name
         self.interface = interface
         self._bufsize = BUFSIZE
-        self.streamable = False  # overrides cam settings
         self.verbose = False
 
         try:

--- a/src/instamatic/camera/videostream.py
+++ b/src/instamatic/camera/videostream.py
@@ -10,7 +10,7 @@ from typing import Any, Generator, List, Optional, Type, TypeVar, Union
 
 import numpy as np
 
-from instamatic.camera import Camera
+from instamatic.camera import get_camera
 from instamatic.camera.camera_base import CameraBase
 from instamatic.image_utils import autoscale
 
@@ -115,7 +115,7 @@ class VideoStream(threading.Thread):
         cls: Type[VideoStream_T], cam: Union[CameraBase, str] = 'simulate'
     ) -> VideoStream_T:
         """Create a subclass based on passed cam or cam-str stream-ability."""
-        cam: CameraBase = Camera(name=cam) if isinstance(cam, str) else cam
+        cam: CameraBase = get_camera(name=cam) if isinstance(cam, str) else cam
         if cls is VideoStream:
             return (LiveVideoStream if cam.streamable else FakeVideoStream)(cam)
         return cls(cam)
@@ -123,7 +123,7 @@ class VideoStream(threading.Thread):
     def __init__(self, cam: Union[CameraBase, str] = 'simulate') -> None:
         threading.Thread.__init__(self)
 
-        self.cam: CameraBase = Camera(name=cam) if isinstance(cam, str) else cam
+        self.cam: CameraBase = get_camera(name=cam) if isinstance(cam, str) else cam
         self.lock = threading.Lock()
 
         self.default_exposure = self.cam.default_exposure

--- a/src/instamatic/config/autoconfig.py
+++ b/src/instamatic/config/autoconfig.py
@@ -125,12 +125,12 @@ It establishes a connection to the microscope and reads out the camera lengths a
         cam_connect = False
         cam_name = None
 
-    from instamatic.camera.camera import get_cam
+    from instamatic.camera.camera import get_camera_class
     from instamatic.controller import TEMController
     from instamatic.microscope import get_microscope_class
 
     if cam_connect:
-        cam = get_cam(cam_name)() if cam_name else None
+        cam = get_camera_class(cam_name)() if cam_name else None
     else:
         cam = None
 

--- a/src/instamatic/controller.py
+++ b/src/instamatic/controller.py
@@ -9,7 +9,7 @@ import numpy as np
 import yaml
 
 from instamatic import config
-from instamatic.camera import Camera
+from instamatic.camera import get_camera
 from instamatic.camera.camera_base import CameraBase
 from instamatic.exceptions import TEMControllerError
 from instamatic.formats import write_tiff
@@ -61,7 +61,7 @@ def initialize(
 
         print(f'Camera    : {cam_name}{cam_tag}')
 
-        cam = Camera(cam_name, as_stream=stream, use_server=use_cam_server)
+        cam = get_camera(cam_name, as_stream=stream, use_server=use_cam_server)
     else:
         cam = None
 

--- a/src/instamatic/microscope/client.py
+++ b/src/instamatic/microscope/client.py
@@ -125,10 +125,6 @@ class MicroscopeClient:
         }
         self._dct['get_attrs'] = None
 
-    def _init_attr_dict(self):
-        """Get list of attrs and their types."""
-        self._attr_dct = self.get_attrs()
-
     def __dir__(self) -> list:
         return list(self._dct.keys())
 

--- a/src/instamatic/microscope/microscope.py
+++ b/src/instamatic/microscope/microscope.py
@@ -10,7 +10,7 @@ default_tem_interface = config.microscope.interface
 __all__ = ['get_microscope', 'get_microscope_class']
 
 
-def get_microscope_class(interface: str) -> 'type[MicroscopeBase]':
+def get_microscope_class(interface: str) -> type[MicroscopeBase]:
     """Grab tem class with the specific 'interface'."""
     simulate = config.settings.simulate
 
@@ -42,7 +42,7 @@ def get_microscope(name: Optional[str] = None, use_server: bool = False) -> Micr
     use_server: bool
         Connect to microscope server running on the host/port defined in the config file
 
-    returns: TEM interface class
+    returns: TEM interface class instance
     """
     if name is None:
         interface = default_tem_interface

--- a/src/instamatic/server/cam_server.py
+++ b/src/instamatic/server/cam_server.py
@@ -11,7 +11,7 @@ import traceback
 import numpy as np
 
 from instamatic import config
-from instamatic.camera import Camera
+from instamatic.camera import get_camera
 from instamatic.utils import high_precision_timers
 
 from .serializer import dumper, loader
@@ -81,7 +81,7 @@ class CamServer(threading.Thread):
 
     def run(self):
         """Start server thread."""
-        self.cam = Camera(name=self._name, use_server=False)
+        self.cam = get_camera(name=self._name, use_server=False)
         self.cam.get_attrs = self.get_attrs
 
         print(f'Initialized camera: {self.cam.interface}')


### PR DESCRIPTION
### Context

Currently, Instamatic does not allow cameras running on server to stream images at all. There are two layers of security that prevent this at different levels. From my discussion with @stefsmeets I concluded that the reason behind that is mostly historical/practical. The initial development of Instamatic was done on a relatively slow camera that did not allow streaming, and since then a lot of work was done on fast local cameras that did not require the client-server architecture.

The main goal of this PR is to allow cameras running on server, such as the new [instamatic-TEM-emulator](https://github.com/instamatic-dev/instamatic-TEM-emulator/), to stream their data via shared memory. In vacuum, this could be achieved by removing only two lines of code, as noted in #140 discussion. However, this introduced another problem - what if due to practical reasons someone actually wanted their camera to be non-streamable? To address this case, this PR also introduces a new camera config parameter, `config.camera.streamable` that, when set to either True or False, overwrites the default class variable for given camera.

Other than allowing streamable server cameras, this PR introduces a few code base improvements. Firstly, it aligns the code conventions used in the camera client code to ones introduced to microscope files by @viljarjf in #99. Furthermore, it allows cameras to call methods that do not exist in their namespace (but may still be accessible on the server) to reflect an analogous change introduced in #108. It slightly improves some docstrings and type hints.

### Development note

Having documented all relevant changes, I decided to share some of my notes on writing this thing, because in the process of adding 3 lines for 3 hours I learned that apparently the Instamatic client-server architecture for cameras is heavily reliant on black magic. Buckle up and grab some popcorn!

`instamatic.camera.camera_base:CameraBase` is a relatively recent class, introduced to Instamatic by @viljarjf in #91. Acting as the base class of all cameras, it includes a very helpful method `load_defaults` that populates the camera namespace with the camera config. Therefore, it is incredibly easy to add new instance variable and even overwrite camera class variables - just add `key: value` to `camera.yaml` and poof! Suddenly your `ctrl.cam` object has access to any `value` desired!

On paper, it works great! However, it acts really strange when observed via the lens of `CamClient` i.e. when using a server. `CamClient` overloads `__getattr__` in a very ingenious way. The old implementation first determines `self._dct` (namespace of local camera class) and `self._attr_dct`, attribute space of the remote camera class. If the local class has `attr_name` in its namespace, `__getattr__` will call server implementation of `attr_name` but wrap it in local `attr_name` so that the Exceptions are easy to understand. If `attr_name` does not exist in local namespace but does remotely, it will be called without wrapping:

```python
    def __getattr__(self, attr_name):
        if attr_name in self._dct:
            wrapped = self._dct[attr_name]
        elif attr_name in self._attr_dct:
            dct = {'attr_name': attr_name}
            return self._eval_dct(dct)
        else:
            raise AttributeError(f'`{self.__class__.__name__}` object has no attribute `{attr_name}`')

        @wraps(wrapped)
        def wrapper(*args, **kwargs):
            dct = {'attr_name': attr_name, 'args': args, 'kwargs': kwargs}
            return self._eval_dct(dct)

        return wrapper
```

So here is when things get very funny: `streamable` is a class attribute of every camera class. Therefore, `streamable` exists in the local class namespace as logged in `self._dct`. Therefore, whenever `camera.streamable` is called, `__getattr__` first looks it up in the local class and runs `wrapped = self._dct[attr_name]` which evaluates to... `True`. Since no other checks are run after that, the bottom wrapping code runs as normal and, by a reason I still fully fail to understand, by adding `streamable = False` to the config and calling `camera.streamable`, instead of getting a `False`, you get a wrapper that must be called to get this value!

Attempts to fix this behavior was very annoying because of recursion and the odd nature of `self._dct` and `self._attr_dct`. Ultimately, I managed to fix it by changing the first part of `__getattr__` to the following:
```python
    def __getattr__(self, attr_name):
        if attr_name in self._dct:
            if attr_name in object.__getattribute__(self, '_attr_dct'):
                return self._eval_dct({'attr_name': attr_name})
            wrapped = self._dct[attr_name]
        elif attr_name in self._attr_dct:
            dct = {'attr_name': attr_name}
            return self._eval_dct(dct)
        else:
            wrapped = None
```

The top addition of conditional `if attr_name in object.__getattribute__(self, '_attr_dct')` checks whether an attribute is present in both local class and on server, in which case it takes its value from the latter. This makes behavior of class variable normal again, in particular `self.streamable = True` now. You will also see that I prevent the `AttributeError` from being raised if `attr_name` is not found, in line with #108. This change is necessary for external server camera to work! AFAIK in #91, `get_camera_dimensions()` method was moved from individual cameras to the `CameraBase` - but the scope of `CameraBase` is not read by `CamClient` which believes that this method is thus undefined and falsely raises `AttributeError` whenever you try to display any image from server camera using `FakeVideoStream`. So this issue is also fixed here.