### PR TITLE
Improve the readability of beam shift calibration code & results

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -243,9 +243,9 @@ This file holds the specifications of the camera. This file is must be located t
 : Set the correction ratio for the cross pixels in the Timepix detector, default: 3.
 
 **calib_beamshift**
-: Set up the grid and stepsize for the calibration of the beam shift in SerialED. The calibration will run a grid of `stepsize` by `stepsize` points, with steps of `stepsize`. The stepsize must be given corresponding to 2500x, and instamatic will then adjust the stepsize depending on the actual magnification, if needed. For example:
+: Set up the grid and stepsize for the calibration of the beam shift in SerialED. The calibration will run a grid of `stepsize` by `stepsize` points, with steps of `stepsize`. The stepsize must be given corresponding to 2500x, and instamatic will then adjust the stepsize depending on the actual magnification, if needed. If the beam moves too slow, a `delay` between setting beam shift and getting image can be introduced. For example:
 ```yaml
-{gridsize: 5, stepsize: 500}
+{gridsize: 5, stepsize: 500, delay: 0.5}
 ```
 
 **calib_directbeam**

--- a/src/instamatic/calibrate/calibrate_beamshift.py
+++ b/src/instamatic/calibrate/calibrate_beamshift.py
@@ -87,7 +87,7 @@ class CalibBeamShift:
             raise OSError(f'{e.strerror}: {fn}. Please run {prog} first.')
 
     @classmethod
-    def live(cls, ctrl, outdir='.', vsp: Optional[VideoStreamProcessor] = None) -> Self:
+    def live(cls, ctrl, outdir: AnyPath='.', vsp: Optional[VideoStreamProcessor] = None) -> Self:
         while True:
             c = calibrate_beamshift(ctrl=ctrl, save_images=True, outdir=outdir)
             with c.annotate_videostream(vsp) if vsp else nullcontext():

--- a/src/instamatic/calibrate/calibrate_beamshift.py
+++ b/src/instamatic/calibrate/calibrate_beamshift.py
@@ -23,6 +23,7 @@ from instamatic.formats import read_tiff
 from instamatic.image_utils import autoscale, imgscale
 from instamatic.processing.find_holes import find_holes
 from instamatic.tools import find_beam_center
+from instamatic.utils.yaml import Numpy2DDumper
 
 if TYPE_CHECKING:
     from instamatic.gui.videostream_processor import DeferredImageDraw, VideoStreamProcessor
@@ -80,7 +81,7 @@ class CalibBeamShift:
         """Read calibration from file."""
         try:
             with open(Path(fn), 'r') as yaml_file:
-                return cls(**yaml.safe_load(yaml_file))
+                return cls(**{k: np.array(v) for k, v in yaml.safe_load(yaml_file).items()})
         except OSError as e:
             prog = 'instamatic.calibrate_beamshift'
             raise OSError(f'{e.strerror}: {fn}. Please run {prog} first.')
@@ -99,7 +100,7 @@ class CalibBeamShift:
         yaml_dict = asdict(self)  # type: ignore[arg-type]
         yaml_dict = {k: v.tolist() for k, v in yaml_dict.items() if k != 'images'}
         with open(yaml_path, 'w') as yaml_file:
-            yaml.safe_dump(yaml_dict, yaml_file)
+            yaml.dump(yaml_dict, yaml_file, Dumper=Numpy2DDumper, default_flow_style=None)
 
     def plot(self, to_file: Optional[AnyPath] = None):
         """Assuming the data is present, plot the data."""

--- a/src/instamatic/calibrate/calibrate_beamshift.py
+++ b/src/instamatic/calibrate/calibrate_beamshift.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 import sys
+import time
 from contextlib import contextmanager, nullcontext
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
@@ -197,6 +198,7 @@ def calibrate_beamshift_live(
     for i, (dx, dy) in enumerate(progress_bar):
         ctrl.beamshift.set(x=float(x_cent + dx), y=float(y_cent + dy))
         progress_bar.set_postfix_str(ctrl.beamshift)
+        time.sleep(config.camera.calib_beamshift.get('delay', 0.0))
 
         kwargs['out'] = Path(outdir) / f'calib_beamshift_{i:04d}' if save_images else None
         comment = f'Calib image {i}: dx={dx} - dy={dy}'

--- a/src/instamatic/calibrate/calibrate_beamshift.py
+++ b/src/instamatic/calibrate/calibrate_beamshift.py
@@ -68,7 +68,7 @@ class CalibBeamShift:
         return self.reference_shift - np.dot(pc - self.reference_pixel, self.transform)
 
     @classmethod
-    def from_data(cls, pixels, shifts, reference_pixel, reference_shift, images=None) -> Self:
+    def from_data(cls, pixels: VectorNx2, shifts: VectorNx2, reference_pixel: Vector2, reference_shift: Vector2, images: Optional[list[np.ndarray]] = None) -> Self:
         r = fit_affine_transformation(pixels, shifts).r
         c = cls(transform=r, reference_pixel=reference_pixel, reference_shift=reference_shift)
         c.pixels = pixels

--- a/src/instamatic/calibrate/calibrate_beamshift.py
+++ b/src/instamatic/calibrate/calibrate_beamshift.py
@@ -58,15 +58,13 @@ class CalibBeamShift:
 
     def beamshift_to_pixelcoord(self, beamshift: Sequence[float, float]) -> Vector2:
         """Converts from beamshift x,y to pixel coordinates."""
-        bs = np.array(beamshift)
         r_i = np.linalg.inv(self.transform)
-        return np.dot(self.reference_shift - bs, r_i) + self.reference_pixel
+        return np.dot(self.reference_shift - np.array(beamshift), r_i) + self.reference_pixel
 
     def pixelcoord_to_beamshift(self, pixelcoord: Sequence[float, float]) -> Vector2:
         """Converts from pixel coordinates to beamshift x,y."""
-        r = self.transform
         pc = np.array(pixelcoord)
-        return self.reference_shift - np.dot(pc - self.reference_pixel, r)
+        return self.reference_shift - np.dot(pc - self.reference_pixel, self.transform)
 
     @classmethod
     def from_data(cls, pixels, shifts, reference_pixel, reference_shift, images=None) -> Self:
@@ -152,7 +150,7 @@ def calibrate_beamshift_live(
     save_images: bool = False,
     outdir: AnyPath = '.',
     **kwargs,
-):
+) -> CalibBeamShift:
     """Calibrate pixel->beamshift coordinates live on the microscope.
 
     ctrl: instance of `TEMController`
@@ -211,8 +209,6 @@ def calibrate_beamshift_live(
         shifts.append(np.array(h['BeamShift']))
 
     print('')
-    # print "\nReset to center"
-
     ctrl.beamshift.set(*(float(_) for _ in beamshift_cent))
 
     # normalize to binsize = 1 and 512-pixel image scale before initializing

--- a/src/instamatic/calibrate/calibrate_beamshift.py
+++ b/src/instamatic/calibrate/calibrate_beamshift.py
@@ -123,11 +123,12 @@ class CalibBeamShift:
 
         vsp.temporary_frame = np.max(self.images, axis=0)
         print('Determined (blue) vs calibrated (orange) beam positions:')
-        print(self.reference_pixel)
-        for p, s in zip(self.pixels + self.reference_pixel, shifts + self.reference_pixel):
+        for p, s in zip(self.pixels, shifts):
+            p = (p + self.reference_pixel)[::-1]  # xy coords inverted for plot
+            s = (s + self.reference_pixel)[::-1]  # xy coords inverted for plot
             ins.append(vsp.draw.circle(p, radius=3, fill='blue'))
             ins.append(vsp.draw.circle(s, radius=3, fill='orange'))
-        ins.append(vsp.draw.circle(self.reference_pixel, radius=3, fill='black'))
+        ins.append(vsp.draw.circle(self.reference_pixel[::-1], radius=3, fill='black'))
         yield
         vsp.temporary_frame = None
         for i in ins:

--- a/src/instamatic/calibrate/filenames.py
+++ b/src/instamatic/calibrate/filenames.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 CALIB_STAGE_LOWMAG = 'calib_stage_lowmag.pickle'
-CALIB_BEAMSHIFT = 'calib_beamshift.pickle'
+CALIB_BEAMSHIFT = 'calib_beamshift.yaml'
 CALIB_BRIGHTNESS = 'calib_brightness.pickle'
 CALIB_DIFFSHIFT = 'calib_diffshift.pickle'
 CALIB_DIRECTBEAM = 'calib_directbeam.pickle'

--- a/src/instamatic/experiments/fast_adt/experiment.py
+++ b/src/instamatic/experiments/fast_adt/experiment.py
@@ -233,7 +233,9 @@ class Experiment(ExperimentBase):
         try:
             return CalibBeamShift.from_file(calib_dir / CALIB_BEAMSHIFT)
         except OSError:
-            return CalibBeamShift.live(self.ctrl, outdir=calib_dir)
+            return CalibBeamShift.live(
+                self.ctrl, outdir=calib_dir, vsp=self.videostream_processor
+            )
 
     def get_dead_time(
         self,

--- a/src/instamatic/utils/yaml.py
+++ b/src/instamatic/utils/yaml.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import numpy as np
+import yaml
+
+
+def _numpy_2d_representer(dumper: yaml.Dumper, array: np.ndarray) -> yaml.nodes.SequenceNode:
+    """Limit the number of newlines when writing numpy arrays where ndim>1."""
+    data = array.tolist()
+
+    if array.ndim == 1:
+        node = dumper.represent_list(data)
+        node.flow_style = True
+    elif array.ndim >= 2:
+        outer = []
+        for row in data:
+            inner = dumper.represent_list(row)
+            inner.flow_style = True
+            outer.append(inner)
+        node = yaml.SequenceNode(tag='tag:yaml.org,2002:seq', value=outer, flow_style=False)
+    else:
+        node = dumper.represent_list(data)
+    return node
+
+
+class Numpy2DDumper(yaml.SafeDumper):
+    """A yaml Dumper class that does not expand numpy arrays beyond 1st dim."""
+
+
+Numpy2DDumper.add_representer(np.ndarray, _numpy_2d_representer)


### PR DESCRIPTION
While the beam shift calibration class is marked in doc-string as "deprecated", I find it useful for my experiments. However, I sometimes had problems getting it to work, in particular when the beam was larger. The wording across the file is inconsistent, the ways to investigate the results are very limited, and in overall while the calibration asks you if you would like to repeat it when calibrating live, there is little that can be used to evaluate whether the calibration was successful.

This PR involves mostly refactor of the `calibrate_beamshift.py` file intended to increase its readability. This involves several changes to the code structure; however, the overall code capability, including existing API, remains unchanged:

- general: added a lot of type hints and expanded doc-strings;
- general: terms center-"pixel" and beam-"shift" are now always used in this order and consistently;
- `CalibBeamShift`: is now a dataclass;
- `CalibBeamShift`: all use of  "pixel" and "shift" are now ordered this way and consistent;
- `CalibBeamShift`: `beamshift_to_pixelcoord` and `pixelcoord_to_beamshift` don't crash at list/tuple-like inputs;
- `CalibBeamShift`: `from_data` can now store images (for plotting) instead of headers (unused);
- `CalibBeamShift`: `from_file`/`to_file` now serializes to a human-readable `yaml` instead of `pickle`;
  - A new yaml dumper warrants that the 2D `np.ndarray`s are easily readable upon dumping (see below);
- `CalibBeamShift`: simplified `plot`, raises rather than exiting at no data (unused, more future-proof);
- `CalibBeamShift`: Added `annotate_videostream` used in `live` to show calibration results in the GUI (see below);
- `calibrate_beamshift` was de-cluttered and simplified, 
- `calibrate_beamshift` can now use `camera.calib_beamshift.delay` between images (if beam shift is slow);
- `calibrate_beamshift`: reimplemented `instamatic.tools.printer` progress bar display using `tqdm.tqdm`
- `calibrate_beamshift_from_image_fn`: fixed (unusable due to broken import - still unsure why it needs a hole though);

This PR does not introduce any changes to API, just code quality and ease of interpretation. Existing code should work mostly just as before. Running calibration with even-sized grid should now work properly. The calibration will now be saved as a human-readable yaml file, e.g. for grid size 3:
```yaml
pixels:
- [133.8375, 152.1796875]
- [-237.13828125, 150.26484374999998]
- [124.96875, -18.24140625]
- [-146.23359374999998, 122.85234375]
- [-138.0703125, 0.9070312500000001]
- [-118.11562500000001, -65.5078125]
- [109.8515625, 153.99375]
- [-255.07734375, 121.03828125]
- [-113.78203125, -157.21875]
reference_pixel: [104.0465625, 436.61460937500004]
reference_shift: [60029, 61754]
shifts:
- [-50.0, -50.0]
- [-50.0, 0.0]
- [-50.0, 50.0]
- [0.0, -50.0]
- [0.0, 0.0]
- [0.0, 50.0]
- [50.0, -50.0]
- [50.0, 0.0]
- [50.0, 50.0]
transform:
- [0.06492405453091554, -0.029765340275091753]
- [-0.2283134920986265, -0.00846418035740315]
```

After the calibration is complete and when `live` asks whether it should be repeated, the GUI will now display the maximum over all collected calibration images with some dots, blue representing fit- and orange representing modeled- beam positions:

<img width="1237" height="735" alt="calib_mostlyRight" src="https://github.com/user-attachments/assets/3196ca8d-4f43-48ef-8e79-12d505c2aa6b" />


One note for future is that the calibration gets progressively less accurate the bigger the beam is:
| <img width="1237" height="735" alt="calib_bitTooLargeBeam" src="https://github.com/user-attachments/assets/b0bf275a-b4a9-4c9c-993b-4b89edec6b07" /> | <img width="1237" height="735" alt="calib_tooLargeBeam" src="https://github.com/user-attachments/assets/1cf741eb-7f7e-4a11-9593-b353db57383c" /> |
| --- | --- | 