### PR TITLE
Remove redundant `triggerEvent` and `set_trigger` boilerplate

### DIFF
--- a/src/instamatic/gui/autocred_frame.py
+++ b/src/instamatic/gui/autocred_frame.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import datetime
-import os
 import pickle
 import threading
 from pathlib import Path
@@ -14,10 +13,10 @@ from instamatic import config
 from instamatic.calibrate import CalibBeamShift
 from instamatic.calibrate.filenames import *
 
-from .base_module import BaseModule
+from .base_module import BaseModule, HasQMixin
 
 
-class ExperimentalautocRED(LabelFrame):
+class ExperimentalautocRED(LabelFrame, HasQMixin):
     """Data collection protocol for SerialRED data collection on a high-speed
     Timepix camera using automated screening and crystal tracking.
 
@@ -211,10 +210,6 @@ class ExperimentalautocRED(LabelFrame):
         self.var_backlash = DoubleVar(value=1.0)
         self.var_rotspeed = DoubleVar(value=0.86)
 
-    def set_trigger(self, trigger=None, q=None):
-        self.triggerEvent = trigger
-        self.q = q
-
     def start_collection(self):
         self.CollectionStopButton.config(state=NORMAL)
         self.CollectionButton.config(state=DISABLED)
@@ -225,8 +220,6 @@ class ExperimentalautocRED(LabelFrame):
 
         params = self.get_params()
         self.q.put(('autocred', params))
-
-        self.triggerEvent.set()
 
     def stop_collection(self, event=None):
         self.stopEvent_experiment.set()
@@ -314,7 +307,6 @@ class ExperimentalautocRED(LabelFrame):
         difffocus = self.var_diff_defocus.get()
 
         self.q.put(('toggle_difffocus', {'value': difffocus, 'toggle': toggle}))
-        self.triggerEvent.set()
 
     def show_calib_beamshift(self):
         # TODO: use mpl_frame.ShowMatplotlibFig

--- a/src/instamatic/gui/base_module.py
+++ b/src/instamatic/gui/base_module.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from queue import Queue
+
 
 class BaseModule:
     """BaseModule for the gui composition.
@@ -31,3 +33,9 @@ class BaseModule:
         frame = self.tk_frame(parent, **self.kwargs)
         self.frame = frame
         return frame
+
+
+class HasQMixin:
+    """Asserts module.q remains reserved for DataCollectionController.q."""
+
+    q: Queue

--- a/src/instamatic/gui/cred_fei_frame.py
+++ b/src/instamatic/gui/cred_fei_frame.py
@@ -5,10 +5,10 @@ from tkinter.ttk import *
 
 from instamatic.utils.spinbox import Spinbox
 
-from .base_module import BaseModule
+from .base_module import BaseModule, HasQMixin
 
 
-class ExperimentalcRED_FEI(LabelFrame):
+class ExperimentalcRED_FEI(LabelFrame, HasQMixin):
     """Simple panel to assist cRED data collection (mainly rotation control) on
     a FEI microscope."""
 
@@ -94,10 +94,6 @@ class ExperimentalcRED_FEI(LabelFrame):
         self.var_save_tiff = BooleanVar(value=True)
         self.var_save_red = BooleanVar(value=True)
 
-    def set_trigger(self, trigger=None, q=None):
-        self.triggerEvent = trigger
-        self.q = q
-
     def start_collection(self):
         self.StartButton.config(state=DISABLED)
         self.FinalizeButton.config(state=NORMAL)
@@ -114,7 +110,6 @@ class ExperimentalcRED_FEI(LabelFrame):
                 },
             )
         )
-        self.triggerEvent.set()
 
     def stop_collection(self):
         self.StartButton.config(state=NORMAL)
@@ -123,7 +118,6 @@ class ExperimentalcRED_FEI(LabelFrame):
         self.e_rotspeed.config(state=NORMAL)
         params = self.get_params(task='None')
         self.q.put(('credfei', params))
-        self.triggerEvent.set()
 
     def get_params(self, task=None):
         params = {

--- a/src/instamatic/gui/cred_frame.py
+++ b/src/instamatic/gui/cred_frame.py
@@ -6,12 +6,12 @@ from tkinter.ttk import *
 
 from instamatic.utils.spinbox import Spinbox
 
-from .base_module import BaseModule
+from .base_module import BaseModule, HasQMixin
 
 ENABLE_FOOTFREE_OPTION = False
 
 
-class ExperimentalcRED(LabelFrame):
+class ExperimentalcRED(LabelFrame, HasQMixin):
     """GUI panel for doing cRED experiments on a Timepix camera."""
 
     def __init__(self, parent):
@@ -183,10 +183,6 @@ class ExperimentalcRED(LabelFrame):
         self.var_save_dials = BooleanVar(value=True)
         self.var_save_red = BooleanVar(value=True)
 
-    def set_trigger(self, trigger=None, q=None):
-        self.triggerEvent = trigger
-        self.q = q
-
     def start_collection(self):
         # TODO: make a pop up window with the STOP button?
         if self.var_toggle_diff_defocus.get():
@@ -208,8 +204,6 @@ class ExperimentalcRED(LabelFrame):
 
         params = self.get_params()
         self.q.put(('cred', params))
-
-        self.triggerEvent.set()
 
     def stop_collection(self, event=None):
         self.stopEvent.set()
@@ -258,7 +252,6 @@ class ExperimentalcRED(LabelFrame):
         difffocus = self.var_diff_defocus.get()
 
         self.q.put(('relax_beam', {'value': difffocus}))
-        self.triggerEvent.set()
 
     def toggle_footfree(self):
         enable = self.var_toggle_footfree.get()
@@ -274,7 +267,6 @@ class ExperimentalcRED(LabelFrame):
         difffocus = self.var_diff_defocus.get()
 
         self.q.put(('toggle_difffocus', {'value': difffocus, 'toggle': toggle}))
-        self.triggerEvent.set()
 
 
 def acquire_data_cRED(controller, **kwargs):
@@ -301,7 +293,6 @@ def acquire_data_cRED(controller, **kwargs):
 
     if controller.use_indexing_server:
         controller.q.put(('autoindex', {'task': 'run', 'path': cexp.smv_path}))
-        controller.triggerEvent.set()
 
 
 module = BaseModule(

--- a/src/instamatic/gui/cred_tvips_frame.py
+++ b/src/instamatic/gui/cred_tvips_frame.py
@@ -9,12 +9,12 @@ from tkinter.ttk import *
 from instamatic import config
 from instamatic.utils.spinbox import Spinbox
 
-from .base_module import BaseModule
+from .base_module import BaseModule, HasQMixin
 
 barrier = threading.Barrier(2, timeout=60)
 
 
-class ExperimentalTVIPS(LabelFrame):
+class ExperimentalTVIPS(LabelFrame, HasQMixin):
     """GUI panel for doing cRED / SerialRED experiments on a TVIPS camera."""
 
     def __init__(self, parent):
@@ -217,10 +217,6 @@ class ExperimentalTVIPS(LabelFrame):
 
         self.var_goniotool_tx = IntVar(value=1)
 
-    def set_trigger(self, trigger=None, q=None):
-        self.triggerEvent = trigger
-        self.q = q
-
     def invert_angle(self):
         angle = self.var_target_angle.get()
         self.var_target_angle.set(-angle)
@@ -257,7 +253,6 @@ class ExperimentalTVIPS(LabelFrame):
         # self.e_target_angle.config(state=DISABLED)
         params = self.get_params(task='get_ready')
         self.q.put(('cred_tvips', params))
-        self.triggerEvent.set()
 
         def worker(button=None, state=None):
             barrier.wait()  # wait for experiment to be primed
@@ -272,19 +267,16 @@ class ExperimentalTVIPS(LabelFrame):
         self.AcquireButton.config(state=DISABLED)
         params = self.get_params(task='acquire')
         self.q.put(('cred_tvips', params))
-        self.triggerEvent.set()
 
     def stop_collection(self):
         self.enable_ui()
         params = self.get_params(task='stop')
         self.q.put(('cred_tvips', params))
-        self.triggerEvent.set()
 
     def serial_collection(self):
         self.disable_ui()
         params = self.get_params(task='serial')
         self.q.put(('cred_tvips', params))
-        self.triggerEvent.set()
 
     def browse_instructions(self):
         fn = filedialog.askopenfilename(
@@ -342,11 +334,9 @@ class ExperimentalTVIPS(LabelFrame):
 
     def start_liveview(self):
         self.q.put(('ctrl', {'task': 'cam.start_liveview'}))
-        self.triggerEvent.set()
 
     def stop_liveview(self):
         self.q.put(('ctrl', {'task': 'cam.stop_liveview'}))
-        self.triggerEvent.set()
 
     def toggle_diff_defocus(self):
         toggle = self.var_toggle_diff_defocus.get()

--- a/src/instamatic/gui/ctrl_frame.py
+++ b/src/instamatic/gui/ctrl_frame.py
@@ -7,10 +7,10 @@ from tkinter.ttk import *
 from instamatic import config
 from instamatic.utils.spinbox import Spinbox
 
-from .base_module import BaseModule
+from .base_module import BaseModule, HasQMixin
 
 
-class ExperimentalCtrl(LabelFrame):
+class ExperimentalCtrl(LabelFrame, HasQMixin):
     """This panel holds some frequently used functions to control the electron
     microscope."""
 
@@ -210,17 +210,12 @@ class ExperimentalCtrl(LabelFrame):
 
         self.var_stage_wait = BooleanVar(value=True)
 
-    def set_trigger(self, trigger=None, q=None):
-        self.triggerEvent = trigger
-        self.q = q
-
     def set_mode(self, event=None):
         self.ctrl.mode.set(self.var_mode.get())
 
     def set_brightness(self, event=None):
         self.var_brightness.set(self.var_brightness.get())
         self.q.put(('ctrl', {'task': 'brightness.set', 'value': self.var_brightness.get()}))
-        self.triggerEvent.set()
 
     def get_brightness(self, event=None):
         self.var_brightness.set(self.ctrl.brightness.get())
@@ -239,7 +234,6 @@ class ExperimentalCtrl(LabelFrame):
     def set_difffocus(self, event=None):
         self.var_difffocus.set(self.var_difffocus.get())
         self.q.put(('ctrl', {'task': 'difffocus.set', 'value': self.var_difffocus.get()}))
-        self.triggerEvent.set()
 
     def get_difffocus(self, event=None):
         self.var_difffocus.set(self.ctrl.difffocus.get())
@@ -247,7 +241,6 @@ class ExperimentalCtrl(LabelFrame):
     def _set_angle(self, var: Variable) -> None:
         kwargs = {'task': 'stage.set', 'a': var.get(), 'wait': self.var_stage_wait.get()}
         self.q.put(('ctrl', kwargs))
-        self.triggerEvent.set()
 
     def set_negative_angle(self):
         return self._set_angle(self.var_negative_angle)
@@ -280,7 +273,6 @@ class ExperimentalCtrl(LabelFrame):
                 },
             )
         )
-        self.triggerEvent.set()
 
     def get_stage(self, event=None):
         x, y, z, _, _ = self.ctrl.stage.get()
@@ -301,17 +293,14 @@ class ExperimentalCtrl(LabelFrame):
                     },
                 )
             )
-            self.triggerEvent.set()
         else:  # wobbler off
             self.wobble_stop_event.set()
 
     def stage_stop(self):
         self.q.put(('ctrl', {'task': 'stage.stop'}))
-        self.triggerEvent.set()
 
     def find_eucentric_height(self):
         self.q.put(('ctrl', {'task': 'find_eucentric_height'}))
-        self.triggerEvent.set()
 
     def toggle_diff_defocus(self):
         if self.var_diff_defocus_on.get():

--- a/src/instamatic/gui/debug_frame.py
+++ b/src/instamatic/gui/debug_frame.py
@@ -8,7 +8,7 @@ from tkinter.ttk import *
 
 from instamatic import config
 
-from .base_module import BaseModule
+from .base_module import BaseModule, HasQMixin
 
 scripts_drc = config.locations['scripts']
 
@@ -22,7 +22,7 @@ VMHOST = config.settings.VM_server_host
 VMPORT = config.settings.VM_server_port
 
 
-class DebugFrame(LabelFrame):
+class DebugFrame(LabelFrame, HasQMixin):
     """GUI panel with advanced / debugging functions."""
 
     def __init__(self, parent):
@@ -139,20 +139,17 @@ class DebugFrame(LabelFrame):
 
         frame = Frame(self)
 
-        self.resetTriggers = Button(frame, text='Report status', command=self.report_status)
-        self.resetTriggers.grid(row=0, column=0, sticky='EW')
+        self.reportStatus = Button(frame, text='Report status', command=self.report_status)
+        self.reportStatus.grid(row=0, column=0, sticky='EW')
 
-        self.resetTriggers = Button(frame, text='Close down', command=self.close_down)
-        self.resetTriggers.grid(row=0, column=1, sticky='EW')
-
-        self.resetTriggers = Button(frame, text='Reset triggers', command=self.reset_triggers)
-        self.resetTriggers.grid(row=1, column=0, sticky='EW')
+        self.closeDown = Button(frame, text='Close down', command=self.close_down)
+        self.closeDown.grid(row=0, column=1, sticky='EW')
 
         self.openIPython = Button(frame, text='Open IPython shell', command=self.open_ipython)
         self.openIPython.grid(row=1, column=1, sticky='EW')
 
-        self.resetTriggers = Button(frame, text='Empty queue', command=self.empty_queue)
-        self.resetTriggers.grid(row=2, column=0, sticky='EW')
+        self.emptyQueue = Button(frame, text='Empty queue', command=self.empty_queue)
+        self.emptyQueue.grid(row=1, column=0, sticky='EW')
 
         frame.columnconfigure(0, weight=1)
         frame.columnconfigure(1, weight=1)
@@ -175,19 +172,15 @@ class DebugFrame(LabelFrame):
 
     def kill_server(self):
         self.q.put(('autoindex', {'task': 'kill_server'}))
-        self.triggerEvent.set()
 
     def start_server(self):
         self.q.put(('autoindex', {'task': 'start_server'}))
-        self.triggerEvent.set()
 
     def register_server(self):
         self.q.put(('autoindex', {'task': 'register_server'}))
-        self.triggerEvent.set()
 
     def kill_server_xdsVM(self):
         self.q.put(('autoindex_xdsVM', {'task': 'kill_server_xdsVM'}))
-        self.triggerEvent.set()
 
     def start_server_xdsVM(self):
         compos = self.var_e_compo.get()
@@ -209,17 +202,14 @@ class DebugFrame(LabelFrame):
                 },
             )
         )
-        self.triggerEvent.set()
 
     def register_server_xdsVM(self):
         self.q.put(('autoindex_xdsVM', {'task': 'register_server_xdsVM'}))
-        self.triggerEvent.set()
 
     def send_path_to_autosolution(self):
         path = self.var_e_smvpath.get()
 
         self.q.put(('autosolution_path', {'path': path}))
-        self.triggerEvent.set()
 
     def scripts_combobox_update(self, event=None):
         for fn in self.scripts_drc.rglob('*.py'):
@@ -230,14 +220,6 @@ class DebugFrame(LabelFrame):
         self.scripts[fn.name] = fn
         self.e_script_file['values'] = list(self.scripts.keys())
 
-    def set_trigger(self, trigger=None, q=None):
-        self.triggerEvent = trigger
-        self.q = q
-
-    def reset_triggers(self):
-        self.triggerEvent.clear()
-        print('>> trigger event has been reset.')
-
     def empty_queue(self):
         print(f'There are {self.q.qsize()} items left in the queue.')
         while not self.q.empty():
@@ -246,11 +228,9 @@ class DebugFrame(LabelFrame):
 
     def open_ipython(self):
         self.q.put(('debug', {'task': 'open_ipython'}))
-        self.triggerEvent.set()
 
     def report_status(self):
         self.q.put(('debug', {'task': 'report_status'}))
-        self.triggerEvent.set()
 
     def close_down(self):
         script = self.scripts_drc / 'close_down.py'
@@ -258,7 +238,6 @@ class DebugFrame(LabelFrame):
         if not script.exists():
             return OSError(f'No such script: {script}')
         self.q.put(('debug', {'task': 'run_script', 'script': script}))
-        self.triggerEvent.set()
 
     def browse(self):
         fn = tkinter.filedialog.askopenfilename(
@@ -276,7 +255,6 @@ class DebugFrame(LabelFrame):
         if script in self.scripts:
             script = self.scripts[script]
         self.q.put(('debug', {'task': 'run_script', 'script': script}))
-        self.triggerEvent.set()
 
     def run_flatfield_collection(self):
         self.q.put(
@@ -289,7 +267,6 @@ class DebugFrame(LabelFrame):
                 },
             )
         )
-        self.triggerEvent.set()
 
     def toggle_use_shelxt(self):
         enable = self.var_use_shelxt.get()

--- a/src/instamatic/gui/fast_adt_frame.py
+++ b/src/instamatic/gui/fast_adt_frame.py
@@ -9,7 +9,7 @@ from typing import Any, Optional
 from instamatic import controller
 from instamatic.utils.spinbox import Spinbox
 
-from .base_module import BaseModule
+from .base_module import BaseModule, HasQMixin
 
 pad0 = {'sticky': 'EW', 'padx': 0, 'pady': 1}
 pad10 = {'sticky': 'EW', 'padx': 10, 'pady': 1}
@@ -67,7 +67,7 @@ class ExperimentalFastADTVariables:
         }
 
 
-class ExperimentalFastADT(LabelFrame):
+class ExperimentalFastADT(LabelFrame, HasQMixin):
     """GUI panel to perform selected FastADT-style (c)RED & PED experiments."""
 
     def __init__(self, parent):
@@ -75,7 +75,6 @@ class ExperimentalFastADT(LabelFrame):
         self.parent = parent
         self.var = ExperimentalFastADTVariables()
         self.q: Optional[Queue] = None
-        self.triggerEvent: Optional[threading.Event] = None
         self.busy: bool = False
         self.ctrl = controller.get_instance()
 
@@ -212,12 +211,6 @@ class ExperimentalFastADT(LabelFrame):
 
     def start_collection(self) -> None:
         self.q.put(('fast_adt', {'frame': self, **self.var.as_dict()}))
-        self.triggerEvent.set()
-
-    def set_trigger(self, trigger: threading.Event, q: Queue) -> None:
-        """A boilerplate method, connects to a GUI thread and command queue."""
-        self.triggerEvent: threading.Event = trigger
-        self.q: Queue = q
 
 
 def fast_adt_interface_command(controller, **params: Any) -> None:

--- a/src/instamatic/gui/machine_learning_frame.py
+++ b/src/instamatic/gui/machine_learning_frame.py
@@ -10,7 +10,7 @@ import numpy as np
 
 from instamatic.formats import read_image
 
-from .base_module import BaseModule
+from .base_module import BaseModule, HasQMixin
 from .mpl_frame import ShowMatplotlibFig
 
 
@@ -25,7 +25,7 @@ def treeview_sort_column(tv, col, reverse):
     tv.heading(col, command=lambda: treeview_sort_column(tv, col, not reverse))
 
 
-class MachineLearningFrame(LabelFrame):
+class MachineLearningFrame(LabelFrame, HasQMixin):
     """GUI Panel to read in the results from the machine learning algorithm to
     identify good/poor crystals based on their diffraction pattern."""
 
@@ -86,10 +86,6 @@ class MachineLearningFrame(LabelFrame):
         self.fns = {}
         self.var_directory = StringVar(value=Path.cwd())
 
-    def set_trigger(self, trigger=None, q=None):
-        self.triggerEvent = trigger
-        self.q = q
-
     def load_table(self):
         fn = tkinter.filedialog.askopenfilename(
             parent=self.parent, initialdir=self.var_directory.get(), title='Select crystal data'
@@ -125,7 +121,6 @@ class MachineLearningFrame(LabelFrame):
             return
 
         self.q.put(('ctrl', {'task': 'stage.set', 'x': float(stage_x), 'y': float(stage_y)}))
-        self.triggerEvent.set()
 
     def show_image(self):
         row = self.tv.item(self.tv.focus())

--- a/src/instamatic/gui/red_frame.py
+++ b/src/instamatic/gui/red_frame.py
@@ -5,10 +5,10 @@ from tkinter.ttk import *
 
 from instamatic.utils.spinbox import Spinbox
 
-from .base_module import BaseModule
+from .base_module import BaseModule, HasQMixin
 
 
-class ExperimentalRED(LabelFrame):
+class ExperimentalRED(LabelFrame, HasQMixin):
     """GUI panel to perform a simple RED experiment using discrete rotation
     steps."""
 
@@ -99,10 +99,6 @@ class ExperimentalRED(LabelFrame):
         self.var_save_tiff = BooleanVar(value=True)
         self.var_save_red = BooleanVar(value=True)
 
-    def set_trigger(self, trigger=None, q=None):
-        self.triggerEvent = trigger
-        self.q = q
-
     def start_collection(self):
         self.StartButton.config(state=DISABLED)
         self.ContinueButton.config(state=NORMAL)
@@ -111,12 +107,10 @@ class ExperimentalRED(LabelFrame):
         self.e_stepsize.config(state=DISABLED)
         params = self.get_params(task='start')
         self.q.put(('red', params))
-        self.triggerEvent.set()
 
     def continue_collection(self):
         params = self.get_params(task='continue')
         self.q.put(('red', params))
-        self.triggerEvent.set()
 
     def stop_collection(self):
         self.StartButton.config(state=NORMAL)
@@ -126,7 +120,6 @@ class ExperimentalRED(LabelFrame):
         self.e_stepsize.config(state=NORMAL)
         params = self.get_params(task='stop')
         self.q.put(('red', params))
-        self.triggerEvent.set()
 
     def get_params(self, task=None):
         params = {

--- a/src/instamatic/gui/sed_frame.py
+++ b/src/instamatic/gui/sed_frame.py
@@ -9,7 +9,7 @@ from tkinter.ttk import *
 from instamatic.calibrate import CalibDirectBeam
 from instamatic.calibrate.filenames import CALIB_BEAMSHIFT, CALIB_DIRECTBEAM
 
-from .base_module import BaseModule
+from .base_module import BaseModule, HasQMixin
 
 # import matplotlib
 # matplotlib.use('TkAgg')
@@ -50,7 +50,7 @@ message3 = """
 Press <OK> to start"""
 
 
-class ExperimentalSED(LabelFrame):
+class ExperimentalSED(LabelFrame, HasQMixin):
     """GUI panel to start a SerialED experiment."""
 
     def __init__(self, parent):
@@ -129,16 +129,11 @@ class ExperimentalSED(LabelFrame):
         self.var_image_spotsize = IntVar(value=4)
         self.var_diff_brightness = IntVar(value=40000)
 
-    def set_trigger(self, trigger=None, q=None):
-        self.triggerEvent = trigger
-        self.q = q
-
     def start_collection(self):
         okay = tkinter.messagebox.askokcancel('Start experiment', message3, icon='warning')
         if okay:
             params = self.get_params()
             self.q.put(('sed', params))
-            self.triggerEvent.set()
 
     def show_calib_beamshift(self):
         # TODO: use mpl_frame.ShowMatplotlibFig

--- a/src/instamatic/gui/videostream_frame.py
+++ b/src/instamatic/gui/videostream_frame.py
@@ -11,13 +11,13 @@ import numpy as np
 from PIL import Image, ImageTk
 from PIL.Image import Resampling
 
-from instamatic.gui.base_module import BaseModule
+from instamatic.gui.base_module import BaseModule, HasQMixin
 from instamatic.gui.click_dispatcher import ClickDispatcher
 from instamatic.gui.videostream_processor import VideoStreamProcessor
 from instamatic.utils.spinbox import Spinbox
 
 
-class VideoStreamFrame(LabelFrame):
+class VideoStreamFrame(LabelFrame, HasQMixin):
     """GUI panel to continuously display the last frame streamed from the
     camera."""
 
@@ -224,16 +224,10 @@ class VideoStreamFrame(LabelFrame):
     def save_frame(self):
         """Save currently shown raw frame from the stream to a file in cwd."""
         self.q.put(('save_frame', {'frame': self.frame}))
-        self.triggerEvent.set()
 
     def save_image(self):
         """Save currently shown, modified, & scaled image to a file in cwd."""
         self.q.put(('save_image', {'image': self.processor.image}))
-        self.triggerEvent.set()
-
-    def set_trigger(self, trigger=None, q=None):
-        self.triggerEvent = trigger
-        self.q = q
 
     def close(self):
         self.stream.close()


### PR DESCRIPTION
I was reminded of the existence of `set_trigger` boilerplate that defines `q` and `triggerEvent` in all module classes. Upon consideration, I found out that the `triggerEvent` is redundant: `queue.Queue` does already implement a `wait` equivalent to `Event` that is "`set`" whenever something is added. And since the queue is currently limited to one item, I found no need for a separate signalling mechanism, so I decided to suggest removing `triggerEvent` altogether.

Removing `triggerEvent` already nicely simplified `DataCollectionController`. However, I am allergic to boilerplates, so I shifted my gaze towards `q` next. Setting the task queue is naturally necessary, but it does not require the boilerplate method. If we naively remove `set_trigger`, setting the queue for modules becomes straightforward:
```python
        for module in self.app.modules.values():
            module.q = self.q
```

The benefit of this solution is that any new module does not need this obscure boilerplate:
```python
    def set_trigger(self, trigger=None, q=None):
        self.triggerEvent = trigger
        self.q = q
```

The drawback is that now both the programmer and the type-checker do not know anything about the magical `q` that may be defined in the future. To address that, in `src/instamatic/gui/base_module.py` I defined a tiny mix-in class whose role is signalling that `q` will be defined at some point:
```python
class HasQMixin:
    """Asserts module.q remains reserved for DataCollectionController.q."""

    q: Queue
```

Any built-in module now must inherit from this class to signal q will be defined later:
```python
from .base_module import BaseModule, HasQMixin
...
class ExperimentalautocRED(LabelFrame, HasQMixin):
```

Alternatively, if one does not like the idea of this mix-in, cannot import it, or just simply likes to have some boilerplate for a reason incomprehensible to me, they must in their GUI module reserve the namespace for `q` instead:
```python
class ExperimentalautocRED(LabelFrame):
    q: queue.Queue
```
To make sure the module wants to use `q` for the queue and nothing else, the `DataCollectionController` now checks whether `q` is type-hinted but does not exist, which is achieved using one of the methods above:
```python
        for module in self.app.modules.values():
            if 'q' in get_type_hints(module.__class__):
                module.q = getattr(module, 'q', self.q)
```

### Code impact
- Removes repetition: the boilerplate `set_trigger` code and unnecessary variable `triggerEvent`.