### PR TITLE
Restrict mkdocstrings and mkdocstrings-python version range

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,5 +3,5 @@ mkdocs
 mkdocs-jupyter
 mkdocs-gen-files
 mkdocs-material
-mkdocstrings>=0.26
-mkdocstrings-python>=1.10
+mkdocstrings>=0.26,<1.0
+mkdocstrings-python>=1.10,<2.0

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,5 +3,5 @@ mkdocs
 mkdocs-jupyter
 mkdocs-gen-files
 mkdocs-material
-mkdocstrings>=0.26,<1.0
-mkdocstrings-python>=1.10,<2.0
+mkdocstrings>=0.26
+mkdocstrings-python>=1.10

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -69,7 +69,7 @@ plugins:
     handlers:
       python:
         paths: [src]
-        import:
+        inventories:
         - https://docs.python.org/3/objects.inv
         - https://numpy.org/doc/stable/objects.inv
         - https://docs.scipy.org/doc/scipy/objects.inv

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,5 @@
 [![build](https://github.com/instamatic-dev/instamatic/actions/workflows/test.yml/badge.svg)](https://github.com/instamatic-dev/instamatic/actions/workflows/test.yml)
+[![docs](https://camo.githubusercontent.com/3303c8b478a6de9b1e736a919b54d743c7af0ea2c1795cc9ae92ace209c4f5b7/68747470733a2f2f6170702e72656164746865646f63732e6f72672f70726f6a656374732f696e7374616d617469632f62616467652f)](https://app.readthedocs.org/projects/instamatic/builds/)
 [![PyPI - Python Version](https://img.shields.io/pypi/pyversions/instamatic)](https://pypi.org/project/instamatic/)
 [![PyPI](https://img.shields.io/pypi/v/instamatic.svg?style=flat)](https://pypi.org/project/instamatic/)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1090388.svg)](https://doi.org/10.5281/zenodo.1090388)


### PR DESCRIPTION
After merging #154 yesterday I noticed that the docs are not being compiled properly. It seems that recently both mkdocstrings and mkdocstrings-python increased their major version, and the new combination fails with the following exception. I configured read the docs to trigger documentation build on every PR and restricted the version range of both packages to address the issue:

```
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/home/docs/checkouts/readthedocs.org/user_builds/instamatic/envs/latest/lib/python3.11/site-packages/mkdocs/__main__.py", line 370, in <module>
    cli()
  File "/home/docs/checkouts/readthedocs.org/user_builds/instamatic/envs/latest/lib/python3.11/site-packages/click/core.py", line 1485, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/docs/checkouts/readthedocs.org/user_builds/instamatic/envs/latest/lib/python3.11/site-packages/click/core.py", line 1406, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/home/docs/checkouts/readthedocs.org/user_builds/instamatic/envs/latest/lib/python3.11/site-packages/click/core.py", line 1873, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/docs/checkouts/readthedocs.org/user_builds/instamatic/envs/latest/lib/python3.11/site-packages/click/core.py", line 1269, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/docs/checkouts/readthedocs.org/user_builds/instamatic/envs/latest/lib/python3.11/site-packages/click/core.py", line 824, in invoke
    return callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/docs/checkouts/readthedocs.org/user_builds/instamatic/envs/latest/lib/python3.11/site-packages/mkdocs/__main__.py", line 288, in build_command
    build.build(cfg, dirty=not clean)
  File "/home/docs/checkouts/readthedocs.org/user_builds/instamatic/envs/latest/lib/python3.11/site-packages/mkdocs/commands/build.py", line 265, in build
    config = config.plugins.on_config(config)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/docs/checkouts/readthedocs.org/user_builds/instamatic/envs/latest/lib/python3.11/site-packages/mkdocs/plugins.py", line 587, in on_config
    return self.run_event('config', config)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/docs/checkouts/readthedocs.org/user_builds/instamatic/envs/latest/lib/python3.11/site-packages/mkdocs/plugins.py", line 566, in run_event
    result = method(item, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^
  File "/home/docs/checkouts/readthedocs.org/user_builds/instamatic/envs/latest/lib/python3.11/site-packages/mkdocstrings/_internal/plugin.py", line 153, in on_config
    handlers._download_inventories()
  File "/home/docs/checkouts/readthedocs.org/user_builds/instamatic/envs/latest/lib/python3.11/site-packages/mkdocstrings/_internal/handlers/base.py", line 600, in _download_inventories
    handler = self.get_handler(handler_name)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/docs/checkouts/readthedocs.org/user_builds/instamatic/envs/latest/lib/python3.11/site-packages/mkdocstrings/_internal/handlers/base.py", line 581, in get_handler
    self._handlers[name] = module.get_handler(
                           ^^^^^^^^^^^^^^^^^^^
  File "/home/docs/checkouts/readthedocs.org/user_builds/instamatic/envs/latest/lib/python3.11/site-packages/mkdocstrings_handlers/python/_internal/handler.py", line 403, in get_handler
    config=PythonConfig.from_data(**handler_config),
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/docs/checkouts/readthedocs.org/user_builds/instamatic/envs/latest/lib/python3.11/site-packages/mkdocstrings_handlers/python/_internal/config.py", line 1142, in from_data
    return cls(**cls.coerce(**data))
           ^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: PythonConfig.__init__() got an unexpected keyword argument 'import'
```