### PR TITLE
Fix shared memory errors at `cam.get_movie` call and iteration

### DIFF
--- a/src/instamatic/camera/camera_client.py
+++ b/src/instamatic/camera/camera_client.py
@@ -196,7 +196,7 @@ class CamClient:
             print(f'Retrieve data from buffer `{name}`')
 
         buffer = self.buffers[name]
-        data = buffer[:]
+        data = buffer[:].copy()
 
         return data
 

--- a/src/instamatic/camera/camera_client.py
+++ b/src/instamatic/camera/camera_client.py
@@ -127,7 +127,7 @@ class CamClient:
         with self._eval_lock:
             self.s.send(dumper(dct))
 
-            acquiring_image = dct['attr_name'] in {'get_image', 'get_movie', '__gen_next__'}
+            acquiring_image = dct['attr_name'] in {'get_image', '__gen_next__'}
 
             if acquiring_image and not self.use_shared_memory:
                 response = self.s.recv(self._imagebufsize)
@@ -139,7 +139,7 @@ class CamClient:
             else:
                 raise RuntimeError(f'Received empty response when evaluating {dct=}')
 
-            if self.use_shared_memory and acquiring_image:
+            if self.use_shared_memory and acquiring_image and data:
                 data = self.get_data_from_shared_memory(**data)
 
             if status == 200:


### PR DESCRIPTION
I am in the process of fixing up any easy yet impactful issues with the Instamatic TEM emulator. When fixing today's issue (https://github.com/instamatic-dev/instamatic-TEM-emulator/pull/3), I noticed that `get_movie` is not handled correctly when using shared memory. This PR fixes fixes the following two actions that caused an unpacking error when using shared memory:

- calling `get_movie` at any point - tried to receive a generator from shared memory;
- calling `__next__` on an exhausted `get_movie` generator - returned None which `_eval_dct` was then attempting to *unpack* in order to pull the next, non-existent, image from shared memory.

With this fix and https://github.com/instamatic-dev/instamatic-TEM-emulator/pull/3 in place, Instamatic can run really cute cRED experiments on the Instamatic TEM emulator:
<img width="1859" height="1108" alt="Screenshot 2026-04-16 195249" src="https://github.com/user-attachments/assets/58cf3cbd-cdb8-4630-908c-f2e553449504" />
