### PR TITLE
You cannot `get_data_from_shared_memory` if data is an error report

### DIFF
--- a/src/instamatic/camera/camera_client.py
+++ b/src/instamatic/camera/camera_client.py
@@ -139,7 +139,7 @@ class CamClient:
             else:
                 raise RuntimeError(f'Received empty response when evaluating {dct=}')
 
-            if self.use_shared_memory and acquiring_image and data:
+            if status == 200 and self.use_shared_memory and acquiring_image and data:
                 data = self.get_data_from_shared_memory(**data)
 
             if status == 200:


### PR DESCRIPTION
When working with a camera via shared memory, any issue should be reported as a tuple of 500 i.e. error code and code description. However, in the current version of the code, if using shared memory is True, the (500, ErrorCode) would be interpreted as instruction for shared memory rather than an error code. Consequently, the error displayed would be along the lines of "cannot interpret (500, ErrorCode) tuple as dict" rather than the actual error that happened on the camera. This PR fixes this little issue, which is especially important when debugging the emulator. With this fix, errors are passed to the main GUI correctly, even if using shared memory is True.