### PR TITLE
Do not disable auto contrast if `display_range` = 255

### DIFF
--- a/src/instamatic/camera/camera_client.py
+++ b/src/instamatic/camera/camera_client.py
@@ -139,7 +139,7 @@ class CamClient:
             else:
                 raise RuntimeError(f'Received empty response when evaluating {dct=}')
 
-            if self.use_shared_memory and acquiring_image and data:
+            if status == 200 and self.use_shared_memory and acquiring_image and data:
                 data = self.get_data_from_shared_memory(**data)
 
             if status == 200:

--- a/src/instamatic/gui/videostream_processor.py
+++ b/src/instamatic/gui/videostream_processor.py
@@ -128,12 +128,11 @@ class VideoStreamProcessor:
         if (temporary_image := self.temporary_image) is not None:
             return temporary_image
         if (frame := self.frame) is not None:
-            if self.vsf.display_range != 255.0 or self.vsf.brightness != 1.0:
-                if self.vsf.auto_contrast:
-                    display_range = 1 + np.percentile(frame[::4, ::4], 99.5)
-                else:
-                    display_range = self.vsf.display_range
-                frame = (self.vsf.brightness * 255 / display_range) * frame
+            if self.vsf.auto_contrast:
+                display_range = 1 + np.percentile(frame[::4, ::4], 99.5)
+            else:
+                display_range = self.vsf.display_range
+            frame = (self.vsf.brightness * 255 / display_range) * frame
             frame = np.clip(frame.astype(np.int16), 0, 255).astype(np.uint8)
         if self.draw.instructions:
             image = Image.fromarray(frame).convert(self.color_mode)


### PR DESCRIPTION
For some time, the Instamatic videoframe display (previously `VideoStreamFrame.on_frame`, currently `VideoStreamProcessor.image`) did not run auto-scaling whenever `display_range` was set to 255. The reasoning behind this decision was likely that in such case, the maximum on observed image is 255 and therefore it does not require additional scaling. This thinking is, however, flawed, because you might have an image with 255 range that has lower (or higher, in case of odd behavior) max intensity, and you still need to scale it. This behavior therefore, although intended, behaved as a very odd bug.

Here I remove this condition. With this PR in place, whenever the "autoscaling" is turned on, the image will be always scaled. If the user wants to save on computational power, they can always turn off autoscaling altogether.

Since I consider this to be a simple bug, I will merge that immediately. At best, this change will fix odd behavior for any system that uses 255 scale by default. At worst, it will make image display marginally slower (~53 ms -> ~53.5 ms) for the same users that do not see strange behavior.

| Before (wrong scaling, strange colors) | After (correct scaling even at 255) |
| --- | --- |
| <img width="516" height="516" alt="image_15-56-38_079" src="https://github.com/user-attachments/assets/5c52557a-d282-45c9-988c-ff2531a7a8c6" /> | <img width="516" height="516" alt="image_15-56-33_319" src="https://github.com/user-attachments/assets/b4578491-bf48-4736-b8a7-fd50187d8126" /> |