### PR TITLE
Update installation instruction plus minor autoconfig fix

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -34,11 +34,12 @@ See [instamatic-dev/instamatic-tecnai-server](https://github.com/instamatic-dev/
 
 ## Installation
 
-If you use conda, create a new environment:
+If you use conda, create a new environment with a supported version of python. For maximum convenience, install basic libraries as well as `pycifrw` from conda forge:
 
 ```
-conda create -n instamatic python=3.11
+conda create -n instamatic python=3.12
 conda activate instamatic
+conda install numpy matplotlib pycifrw -c conda-forge
 ```
 
 Install using pip, works with python versions 3.9 or newer:
@@ -47,9 +48,11 @@ Install using pip, works with python versions 3.9 or newer:
 pip install instamatic
 ```
 
+Please mind that one of the indirect Instamatic dependencies, PyCifRW, requires Microsoft Visual C++ 14.0 or greater to compile properly. For this reason, when installing instamatic directly from pip, these build tools must be available on the system to succeed. Installing precompiled `pycifrw` from conda-forge circumvents this issue.  
+
 ## OS requirement
 
-The package requires Windows 7 or higher. It has been mainly developed and tested under Windows 7 and higher.
+The package requires Windows 7 or higher. It has been mainly developed and tested under Windows 7 and higher. Client and camera server installation were shown to successfully run on Unix-based systems but may require additional care. Microscope server installations require Windows OS for communication with the TEM.
 
 ## Package dependencies
 

--- a/src/instamatic/camera/camera_client.py
+++ b/src/instamatic/camera/camera_client.py
@@ -139,7 +139,7 @@ class CamClient:
             else:
                 raise RuntimeError(f'Received empty response when evaluating {dct=}')
 
-            if self.use_shared_memory and acquiring_image and data:
+            if status == 200 and self.use_shared_memory and acquiring_image and data:
                 data = self.get_data_from_shared_memory(**data)
 
             if status == 200:

--- a/src/instamatic/config/autoconfig.py
+++ b/src/instamatic/config/autoconfig.py
@@ -206,7 +206,7 @@ It establishes a connection to the microscope and reads out the camera lengths a
     print(f' 1. Check and update the pixelsizes in `{calib_config_fn}`')
     print('    - In real space, pixelsize in nm')
     print('    - In reciprocal space, pixelsize in px/Angstrom')
-    print(f' 2. Check and update magnification ranges in `{microscope_config_fn}`')
+    print(f' 2. Check and update magnification ranges in `{tem_config_fn}`')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
On the recent NEMI workshop in Trondheim, we had a practical dedicated to installing and configuring Instamatic; for its purpose, with great help of @magnunor I managed to investigate successful Instamatic installation routines. As we noticed, `PyCifRW` is an indirect dependency of Instamatic that needs to be either compiled (requires heavy C++ machinery) or pulled pre-compiled from conda-forge. Either of these solutions is not exactly obvious, so I decided to update the README.MD to include this detail there to save a few hours to any potential new users tacking with this issue later.

On another side, as Andy Steward reported, for a very long time Instamatic had a typo that prevented `instamatic.autoconfig.exe` from running properly. The typo did nothing but raised a big and scary exception message. Here I fix it.

Since this does not affect the core Instamatic code whatsoever, I intend to merge it in a few days, unless questions are raised.