### PR TITLE
 Pre-set beamshift before FastADT to avoid missing first frame

### DIFF
--- a/src/instamatic/camera/camera_client.py
+++ b/src/instamatic/camera/camera_client.py
@@ -139,7 +139,7 @@ class CamClient:
             else:
                 raise RuntimeError(f'Received empty response when evaluating {dct=}')
 
-            if self.use_shared_memory and acquiring_image and data:
+            if status == 200 and self.use_shared_memory and acquiring_image and data:
                 data = self.get_data_from_shared_memory(**data)
 
             if status == 200:

--- a/src/instamatic/experiments/fast_adt/experiment.py
+++ b/src/instamatic/experiments/fast_adt/experiment.py
@@ -139,8 +139,7 @@ class Run:
     def has_beamshifts(self) -> bool:
         columns = ['beamshift_x', 'beamshift_y']
         columns_exist = set(columns).issubset(self.table.columns)
-        columns_have_nans = self.table[columns].isna().any().any()
-        return columns_exist and not columns_have_nans
+        return columns_exist and not self.table[columns].isna().any().any()
 
     @property
     def osc_angle(self) -> float:

--- a/src/instamatic/experiments/fast_adt/experiment.py
+++ b/src/instamatic/experiments/fast_adt/experiment.py
@@ -137,7 +137,10 @@ class Run:
 
     @property
     def has_beamshifts(self) -> bool:
-        return {'beamshift_x', 'beamshift_y'}.issubset(self.table.columns)
+        columns = ['beamshift_x', 'beamshift_y']
+        columns_exist = set(columns).issubset(self.table.columns)
+        columns_have_nans = self.table[columns].isna().any().any()
+        return columns_exist and not columns_have_nans
 
     @property
     def osc_angle(self) -> float:
@@ -497,6 +500,8 @@ class Experiment(ExperimentBase):
 
     def collect_run(self, run: Run) -> None:
         """Collect `run.steps` and place them in `self.steps` Queue."""
+        if run.has_beamshifts:
+            self.ctrl.beamshift.set(*run.table[['beamshift_x', 'beamshift_y']].iloc[0])
         with self.ctrl.beam.unblanked(delay=0.2):
             if run.continuous:
                 self._collect_scans(run=run)


### PR DESCRIPTION
In the current version of FastADT experiment, the loop responsible for collecting the data typically looks something like this (simplification):
```python
movie = self.ctrl.get_movie(n_frames=len(run) - 1, exposure=run.exposure)
with self.ctrl.stage.rotation_speed(speed=rot_speed):
    self.ctrl.stage.set(a=target_alpha, wait=False)
    for step, (image, meta) in zip(run.steps, movie):
        # this code runs only after movie image is collected
        if run.has_beamshifts:
            self.ctrl.beamshift.set(step.beamshift_x, step.beamshift_y)
```
The beamshifts, collected and extrapolated before diffraction experiment, are applied only after the stage movement and movie collection has already started. This means that the first collected image is never preceded by any `beamshift.set` statement. Unless the beam randomly happens to be at a correct position, the first frame will be always empty and should be rejected.

This PR adds a new `beamshift.set` command just before opening the beam blank, which itself introduces small delay, so that the first image already has a beam deflected towards the starting position. Since the beam shifts can now be taken from a file following #159, it also checks if none of the beam shifts is NaN.