### PR TITLE
Pairing functions and minor utils/typing/doc fixes

### DIFF
--- a/src/instamatic/_typing.py
+++ b/src/instamatic/_typing.py
@@ -7,4 +7,5 @@ from typing_extensions import Annotated
 
 AnyPath = Union[str, os.PathLike]
 int_nm = Annotated[int, 'Length expressed in nanometers']
+float_nm = Annotated[float, 'Length expressed in nanometers']
 float_deg = Annotated[float, 'Angle expressed in degrees']

--- a/src/instamatic/camera/camera_client.py
+++ b/src/instamatic/camera/camera_client.py
@@ -139,7 +139,7 @@ class CamClient:
             else:
                 raise RuntimeError(f'Received empty response when evaluating {dct=}')
 
-            if self.use_shared_memory and acquiring_image and data:
+            if status == 200 and self.use_shared_memory and acquiring_image and data:
                 data = self.get_data_from_shared_memory(**data)
 
             if status == 200:

--- a/src/instamatic/controller.py
+++ b/src/instamatic/controller.py
@@ -709,7 +709,7 @@ class TEMController:
         comment: str = '',
         header_keys: Tuple[str] = MOVIE_HEADER_KEYS_VARIABLE,
         header_keys_common: Tuple[str] = MOVIE_HEADER_KEYS_COMMON,
-    ) -> Generator[np.ndarray, None, None]:
+    ) -> Generator[tuple[np.ndarray, dict], None, None]:
         """Generate (image, header) pairs using camera's movie mode. If the
         exposure and binsize are not given, the default values are read from
         the config file. Common header info is collected before the generator
@@ -732,8 +732,8 @@ class TEMController:
 
         Yields
         -------
-        image_header: Generator[(np.ndarray, collections.ChainMap), None, None]
-            Generator of (numpy arrays with image data, ChainMap with
+        image_header: Generator[(np.ndarray, dict), None, None]
+            Generator of (numpy arrays with image data, dict with
             all the tem parameters and image attributes) pairs.
 
         Usage:

--- a/src/instamatic/utils/iterating.py
+++ b/src/instamatic/utils/iterating.py
@@ -6,13 +6,15 @@ from typing import Iterable, Iterator, TypeVar
 T = TypeVar('T')
 
 
-def pairwise(iterable: Iterable[T]) -> Iterator[tuple[T, T]]:
+def pairwise(iterable: Iterable[T], closed: bool = False) -> Iterator[tuple[T, T]]:
     """Yield pairs of subsequent iterable elements: 'abc' -> (a, b), (b, c)"""
     iterator = iter(iterable)
-    left = next(iterator, None)
+    first = left = next(iterator, None)
     for right in iterator:
         yield left, right
         left = right
+    if closed and first is not None:
+        yield left, first
 
 
 def sawtooth(iterator: Iterable[T]) -> Iterator[T]:

--- a/src/instamatic/utils/pairing.py
+++ b/src/instamatic/utils/pairing.py
@@ -1,0 +1,193 @@
+"""This module deals with pairing functions and their inverses used to map
+between two coordinate systems: a 1D series of natural numbers including zero
+and a 2D space of integers (infinite in both directions).
+
+The space indexing schemes used in this module are as follows:
+- ij - orthogonal 2D grid: i goes right (alongside x), j goes up (with y);
+  This is the typical Cartesian setting used in mathematics.
+- ulam - 1D idx of ortho 2D grid: 0=center, 1=right, then spiral anti-clockwise.
+  Cartesian distance between two subsequent cells is always 1.
+  Maximum distance from zero grows steadily step-wise: 1x0, 8x1, 16x2, 24x3...
+- uv - hexagonal 2D grid (side-flat): u goes right, v +60deg anti-clockwise
+  A popular hexagonal setting: distance between i,j and i+1,j or i,j+1 is 1.
+- hulam - 1D idx of hex 2D grid: 0=center, 1=right, then spiral anti-clockwise
+  Cartesian distance between two subsequent cells is always 1.
+  Hex-Chebyshev distance from zero grows steadily step-wise:
+  One cell in distance 0, six in distance 1, twelve in distance 12...
+
+For further details on the qrs space, see:
+https://www.redblobgames.com/grids/hexagons/ and https://doi.org/10.1117/1.JEI.22.1.010502
+
+The algorithm behind both pairing and inverse functions works as follows:
+- find k: (hex-)chebyshev distance of index n / pair ij or uv from (0, 0)
+- find n0: the lowest (h)ulam index for any index / pair at a given distance k
+- determine on which segment the point is and manually calculate its pair/index
+
+In any 2D space, n0 for given k is always right above the bottom right corner.
+
+In 2D orthogonal space:
+- k-th ring starts at minimum ulam index (2k-1)^2 at orthogonal coords (k, 1-k).
+- k-th ring ends at maximum ulam index (2k+1)^2-1 at orthogonal coords (k, -k).
+
+Ulam index increases when counting along the following segments in this order:
+- Segment 1: Up from bottom-right to top-right corner:  (k, 1-k)   to (k, k).
+- Segment 2: Left from top-right to top-left corner:    (k-1, k)   to (-k, k).
+- Segment 3: Down from top-left to bottom-left corner:  (-k, k-1)  to (-k, -k).
+- Segment 4: Right from bottom-left to b-right corner:  (1-k, -k)  to (k, -k).
+
+In 2D hexagonal space:
+- k-th ring starts at minimum hulam index 3k^2-3k+1 at hex coords (k, 1-k).
+- k-th ring ends at maximum hulam index 3k^2+3k at hexagonal coords (k, -k).
+
+Hulam index (hexagonal) increases along the following segments in this order:
+- Segment 1: Up-right from bottom-right to right corner:  (k, 1-k)  to (k, 0).
+- Segment 2: Up-left from right to top-right corner:      (k-1, 1)  to (0, k).
+- Segment 3: Left top-right to top-left corner:           (-1, k)   to (-k, k).
+- Segment 4: Down-left from top-left to left corner:      (-k, k-1) to (-k, 0).
+- Segment 5: Down-right from left to bottom-left corner:  (1-k, -1) to (0, -k).
+- Segment 6: Right from bottom-left to b-right corner:    (1, -k)   to (k, -k).
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Protocol
+
+
+class PairingFunction(Protocol):
+    def __call__(self, i: int, j: int, /) -> int: ...
+
+
+class PairingInverse(Protocol):
+    def __call__(self, n: int, /) -> tuple[int, int]: ...
+
+
+def ulam2ij(n: int) -> tuple[int, int]:
+    """Convert from index in 1D Ulam to orthogonal (i, j) coordinates.
+
+    k-th ring starts at minimum value of n0 = (2k-1)^2 at coords (k,
+    1-k). k-th ring ends at maximum value of n1 = (2k+1)^2-1 at coords
+    (k, -k).
+    """
+    if n == 0:
+        return 0, 0
+    elif n < 0:
+        raise ValueError(f'Conversion of negative Ulam index {n} is not supported')
+
+    k = math.ceil((math.sqrt(n + 1) - 1) / 2)
+    n0 = (2 * k - 1) ** 2
+    offset = n - n0
+
+    if offset <= 2 * k - 1:  # segment 1
+        return k, -k + 1 + offset
+    elif offset <= 4 * k - 1:  # segment 2
+        return 3 * k - 1 - offset, k
+    elif offset <= 6 * k - 1:  # segment 3
+        return -k, 5 * k - 1 - offset
+    return offset - 7 * k + 1, -k  # segment 4
+
+
+def ij2ulam(i: int, j: int) -> int:
+    """Convert from index in orthogonal (i, j) to 1D Ulam coordinates."""
+    if i == 0 and j == 0:
+        return 0
+
+    k = max(abs(i), abs(j))
+    n0 = (2 * k - 1) ** 2
+
+    if i == k and -k + 1 <= j <= k:  # segment 1
+        return n0 + j + k - 1
+    elif j == k and -k <= i <= (k - 1):  # segment 2
+        return n0 + (2 * k - 1) + (k - i)
+    elif i == -k and -k <= j <= (k - 1):  # segment 3
+        return n0 + (4 * k - 1) + (k - j)
+    return n0 + (6 * k - 1) + (i + k)  # segment 4
+
+
+def hulam2uv(n: int) -> tuple[int, int]:
+    """Convert from 1D hex Ulam index to hexagonal (u, v) coordinates."""
+    if n == 0:
+        return 0, 0
+    elif n < 0:
+        raise ValueError(f'Conversion of negative hulam index {n} is not supported')
+
+    k = math.ceil((math.sqrt(12 * n + 9) - 3) / 6)
+    n0 = 1 + 3 * (k - 1) * k
+    offset = n - n0
+
+    if offset < k:  # Segment 1
+        return k, 1 - k + offset
+    elif offset < 2 * k:  # Segment 2
+        return 2 * k - offset - 1, offset - k + 1
+    elif offset < 3 * k:  # Segment 3
+        return 2 * k - 1 - offset, k
+    elif offset < 4 * k:  # Segment 4
+        return -k, 4 * k - offset - 1
+    elif offset < 5 * k:  # Segment 5
+        return -5 * k + offset + 1, 4 * k - offset - 1
+    return 1 + offset - 5 * k, -k  # Segment 6
+
+
+def uv2hulam(u: int, v: int) -> int:
+    """Convert from index in hexagonal (u, v) coordinates to 1D hex Ulam."""
+
+    if u == 0 and v == 0:
+        return 0
+
+    k = max(abs(u), abs(v), abs(u + v))
+    n0 = 1 + 3 * (k - 1) * k
+
+    if u == k and -k < v <= 0:
+        return n0 + v + k - 1
+    elif u + v == k and u < k:
+        return n0 + k + v - 1
+    elif v == k:
+        return n0 + 2 * k - u - 1
+    elif u == -k:
+        return n0 + 3 * k + k - 1 - v
+    elif u + v == -k:
+        return n0 + 4 * k + u + k - 1
+    return n0 + 5 * k + u - 1
+
+
+if __name__ == '__main__':  # tests
+    # Draw ulam and hulam indices onto a 2x2 matrix of (i,j) for demo/testing.
+
+    import numpy as np
+
+    # 9x9x2 array of (i,j)
+    ij_grid = np.empty((9, 9, 2), dtype=int)
+    for r, j in enumerate(np.arange(4, -5, -1)):
+        for c, i in enumerate(np.arange(-4, 5)):
+            ij_grid[r, c] = (i, j)
+
+    # pretty-print ij grid
+    print('ij grid:')
+    for row in ij_grid:
+        print(' '.join(f'({i:2d},{j:2d})' for i, j in row))
+    print()
+
+    # 9x9 array of Ulam indices
+    ulam_grid = np.empty((9, 9), dtype=int)
+    for r in range(9):
+        for c in range(9):
+            i, j = ij_grid[r, c]
+            ulam_grid[r, c] = ij2ulam(i, j)
+
+    # pretty-print ulam grid
+    print('Ulam index grid:')
+    for row in ulam_grid:
+        print(' '.join(f'{n:4d}' for n in row))
+    print()
+
+    # 9x9 array of Spiral indices
+    hulam_grid = np.empty((9, 9), dtype=int)
+    for r in range(9):
+        for c in range(9):
+            u, v = ij_grid[r, c]
+            hulam_grid[r, c] = uv2hulam(u, v)
+
+    # pretty-print spiral hulam indices
+    print('Hulam index grid:')
+    for i, row in enumerate(hulam_grid):
+        print('  ' * (8 - i) + ' '.join(f'{n:3d}' for n in row))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -9,6 +9,7 @@ import pytest
 
 from instamatic.utils.domains import NumericDomain
 from instamatic.utils.native import AnyNumber, NativeNumber, native
+from instamatic.utils.pairing import hulam2uv, ij2ulam, ulam2ij, uv2hulam
 from tests.utils import InstanceAutoTracker
 
 
@@ -55,3 +56,24 @@ NativeTestCase(input_value=int(1), output_type=int)
 def test_native(test_case) -> None:
     """Assert `native` always returns numpy native NativeNumber types."""
     assert isinstance(native(test_case.input_value), test_case.output_type)
+
+
+# 2D coordinates of the first nine Ulam (u9) and hexagonal Ulam (h9) points:
+u9 = [(0, 0), (1, 0), (1, 1), (0, 1), (-1, 1), (-1, 0), (-1, -1), (0, -1), (1, -1)]
+h9 = [(0, 0), (1, 0), (0, 1), (-1, 1), (-1, 0), (0, -1), (1, -1), (2, -1), (2, 0)]
+
+
+def test_ulam_regular():
+    for ulam_index, ij_coords in enumerate(u9):
+        assert ulam_index == ij2ulam(*ij_coords)
+        assert ij_coords == ulam2ij(ulam_index)
+    for ulam_index in range(100):
+        assert ij2ulam(*ulam2ij(ulam_index)) == ulam_index
+
+
+def test_ulam_hexagonal():
+    for hulam_index, uv_coords in enumerate(h9):
+        assert hulam_index == uv2hulam(*uv_coords)
+        assert uv_coords == hulam2uv(hulam_index)
+    for hulam_index in range(100):
+        assert uv2hulam(*hulam2uv(hulam_index)) == hulam_index


### PR DESCRIPTION
### Context
This PR introduces a few small technical improvements to instamatic utilities and adds a new module to `instamatic.utils`: `pairing` which implements pairing functions based on the ulam spiral (regular and hexagonal variant). The changes are mostly typing or documentation fixes, as well as a new `closed` attribute added to `pairwise` function that allows yielding the last-first pair of points alongside others: 
```python
>>> for a, b in pairwise('ABCD', closed=True)):
>>>    print('{a}{b}')

<<< 'AB'
<<< 'BC'
<<< 'CD'
<<< 'DA'  # this is not yielded in previous version or if closed=False (default)
```

The four new functions (two plus inverse functions) in the `pairing` module include:
- `ulam2ij(n)`: return coordinates of n-th point on regular Ulam spiral;
- `ij2ulam(i, j)`: return regular Ulam index of point (i, j) in orthogonal 2D space;
- `hulam2uv(n)`: return coordinates of n-th point on a hexagonal Ulam spiral;
- `uv2hulam(u, v)`: return hexagonal Ulam index of point (u, v) in hexagonal 2D space.

The hexagonal space is indexed using a "hulam" pairing, ulam spiral analogue, defined as: x axis right, y axis 60 degrees anticlockwise. Both function pairs allow for easy iterating over 2D space points (grid windows or measurement locations) on the grid space using natural numbers. The documentation of individual functions is sparse, because most of their docs is common to all of them and resides in the module `__doc__`. For human eye, the role of this module is best explained using the example from the `if __name__ == "__main__"` block:

```
ij / uj grid:
(-4, 4) (-3, 4) (-2, 4) (-1, 4) ( 0, 4) ( 1, 4) ( 2, 4) ( 3, 4) ( 4, 4)
(-4, 3) (-3, 3) (-2, 3) (-1, 3) ( 0, 3) ( 1, 3) ( 2, 3) ( 3, 3) ( 4, 3)
(-4, 2) (-3, 2) (-2, 2) (-1, 2) ( 0, 2) ( 1, 2) ( 2, 2) ( 3, 2) ( 4, 2)
(-4, 1) (-3, 1) (-2, 1) (-1, 1) ( 0, 1) ( 1, 1) ( 2, 1) ( 3, 1) ( 4, 1)
(-4, 0) (-3, 0) (-2, 0) (-1, 0) ( 0, 0) ( 1, 0) ( 2, 0) ( 3, 0) ( 4, 0)
(-4,-1) (-3,-1) (-2,-1) (-1,-1) ( 0,-1) ( 1,-1) ( 2,-1) ( 3,-1) ( 4,-1)
(-4,-2) (-3,-2) (-2,-2) (-1,-2) ( 0,-2) ( 1,-2) ( 2,-2) ( 3,-2) ( 4,-2)
(-4,-3) (-3,-3) (-2,-3) (-1,-3) ( 0,-3) ( 1,-3) ( 2,-3) ( 3,-3) ( 4,-3)
(-4,-4) (-3,-4) (-2,-4) (-1,-4) ( 0,-4) ( 1,-4) ( 2,-4) ( 3,-4) ( 4,-4)

Ulam index grid:
  64   63   62   61   60   59   58   57   56
  65   36   35   34   33   32   31   30   55
  66   37   16   15   14   13   12   29   54
  67   38   17    4    3    2   11   28   53
  68   39   18    5    0    1   10   27   52
  69   40   19    6    7    8    9   26   51
  70   41   20   21   22   23   24   25   50
  71   42   43   44   45   46   47   48   49
  72   73   74   75   76   77   78   79   80

Hulam index grid:
                 48  47  46  45  44  69 100 137 180
               49  27  26  25  24  43  68  99 136
             50  28  12  11  10  23  42  67  98
           51  29  13   3   2   9  22  41  66
         52  30  14   4   0   1   8  21  40
       81  53  31  15   5   6   7  20  39
    116  82  54  32  16  17  18  19  38
  157 117  83  55  33  34  35  36  37
204 158 118  84  56  57  58  59  60
```

The new functionality introduced here is not used by the current version of instamatic. It may seem controversial, but I have a large update that I would like to publish in October. I decided to publish this smaller update in preparation to the large publication, so that in each pull request, the review focus may remain on the main subject.

### Changes
- `pairwise.py`: Added two Z^2 <–> N_0 pairing bijections in `instamatic.utils`;
- `test_utils.pt`: Added tests for all new functions from `pairwise.py`;
- `iterating.py`: Added `close` argument to `pairwise` to yield "last, first" pair;
- `controller.py`: Fixed `ctrl.get_movie` type hint and documentation;
- `_typing.py`: Added `float_nm` annotated type for when distance is expressed as float.
